### PR TITLE
Fix Fava service URL port from 5000 to 7503

### DIFF
--- a/src/components/widgets/FavaWidget/index.tsx
+++ b/src/components/widgets/FavaWidget/index.tsx
@@ -23,10 +23,14 @@ import {
   ExternalLink
 } from 'lucide-react';
 
+// Base URL for services - override with VITE_SERVICES_BASE_URL env var
+const SERVICES_BASE_URL = import.meta.env.VITE_SERVICES_BASE_URL || 'http://localhost';
+const FAVA_PORT = import.meta.env.VITE_FAVA_PORT || '7503';
+
 const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
   const defaultConfig: FavaWidgetConfig = {
     title: 'Fava',
-    baseUrl: 'http://localhost:5000', // Fava default port
+    baseUrl: `${SERVICES_BASE_URL}:${FAVA_PORT}`,
     beancountPath: 'eleva-spa',
     refreshInterval: 300,
     currency: '$'

--- a/src/components/widgets/ServicesWidget/index.tsx
+++ b/src/components/widgets/ServicesWidget/index.tsx
@@ -46,6 +46,9 @@ const ICONS: Record<string, LucideIcon> = {
 const SERVICES_BASE_URL = import.meta.env.VITE_SERVICES_BASE_URL || 'http://localhost';
 const IS_REMOTE = SERVICES_BASE_URL.includes('https://');
 
+// Service ports - can be overridden with environment variables
+const FAVA_PORT = import.meta.env.VITE_FAVA_PORT || '7503';
+
 // Default services - users can customize URLs in widget settings
 const DEFAULT_SERVICES: Service[] = [
   {
@@ -68,7 +71,7 @@ const DEFAULT_SERVICES: Service[] = [
   {
     id: 'fava',
     name: 'Fava',
-    url: `${SERVICES_BASE_URL}:7503`,
+    url: `${SERVICES_BASE_URL}:${FAVA_PORT}`,
     icon: 'BookOpen',
     description: 'Beancount',
     category: 'Finance'


### PR DESCRIPTION
Port 5000 is used by macOS AirPlay Receiver, causing 403 errors. Fava runs on port 7502 with Caddy proxy on 7503.