### PR TITLE
Run build workflow on all pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,17 +7,6 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
-    paths:
-      - 'src/**'
-      - 'public/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'Dockerfile'
-      - '.dockerignore'
-      - 'docker-compose*.yml'
-      - 'vite.config.ts'
-      - 'tsconfig*.json'
-      - '.github/workflows/docker-publish.yml'
 
 env:
   # Use github.repository as <account>/<repo>


### PR DESCRIPTION
## Summary
- remove the pull_request path filter from the Docker build workflow
- ensure the required build check exists for dependency and backend PRs too
- unblock the currently stalled dependabot PR queue

## Validation
- workflow path restriction removed only; no app code changes
