### PR TITLE
SUS-32 Replace native HTML controls with shadcn/ui components across all widgets

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer", // Add cursor-pointer here
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
   {
     variants: {
       variant: {
@@ -25,6 +25,7 @@ const buttonVariants = cva(
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        none: "h-auto whitespace-normal",
       },
     },
     defaultVariants: {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/components/widgets/CalendarWidget/index.tsx
+++ b/src/components/widgets/CalendarWidget/index.tsx
@@ -14,6 +14,7 @@ import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../../widgets/
 import { WidgetShell } from '../../widgets/common/WidgetShell'
 import { CalendarWidgetProps, CalendarWidgetConfig, CalendarEvent, CalendarSource } from './types'
 import { Button } from '../../ui/button'
+import { Tabs, TabsList, TabsTrigger } from '../../ui/tabs'
 import { Label } from '../../ui/label'
 import { Checkbox } from '../../ui/checkbox';
 
@@ -1711,24 +1712,23 @@ const CalendarWidget: React.FC<CalendarWidgetProps> = ({ width = 2, height = 2, 
           </div>
 
           {/* View mode tabs */}
-          <div className="flex rounded-lg bg-muted p-0.5">
-            {(['month', 'week', 'day'] as const).map(mode => (
-              <button
-                key={mode}
-                onClick={() => {
-                  setViewMode(mode);
-                  updateConfig({ ...localConfig, viewMode: mode });
-                }}
-                className={`px-3 py-1 text-sm rounded-md capitalize transition-colors ${
-                  viewMode === mode
-                    ? 'bg-background shadow-sm font-medium'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
+          <Tabs
+            value={viewMode}
+            onValueChange={(value) => {
+              const nextMode = value as 'month' | 'week' | 'day';
+              setViewMode(nextMode);
+              updateConfig({ ...localConfig, viewMode: nextMode });
+            }}
+            className="w-auto"
+          >
+            <TabsList className="h-auto rounded-lg bg-muted p-0.5">
+              {(['month', 'week', 'day'] as const).map(mode => (
+                <TabsTrigger key={mode} value={mode} className="px-3 py-1 capitalize">
+                  {mode}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
         </div>
       );
     };

--- a/src/components/widgets/CountdownWidget/index.tsx
+++ b/src/components/widgets/CountdownWidget/index.tsx
@@ -810,7 +810,7 @@ const CountdownWidget: React.FC<CountdownWidgetProps> = ({ width, height, config
               <Label>Color</Label>
               <div className="flex gap-2 mt-1">
                 {DEFAULT_COLORS.map((color) => (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={color}
                     className={`h-6 w-6 rounded-full border-2 transition-all ${
                       editingEvent.color === color

--- a/src/components/widgets/CronHealthWidget/index.tsx
+++ b/src/components/widgets/CronHealthWidget/index.tsx
@@ -509,13 +509,13 @@ const CronHealthWidget: React.FC<CronHealthWidgetProps> = ({ width, height, conf
           {/* Filter tabs */}
           <div className="flex border-b border-border/50 px-2 overflow-x-auto">
             {filterTabs.map(tab => (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 key={tab.key}
                 className={`px-3 py-2 text-xs whitespace-nowrap ${filterStatus === tab.key ? 'border-b-2 border-primary font-medium text-foreground' : 'text-muted-foreground hover:text-foreground'}`}
                 onClick={() => setFilterStatus(tab.key)}
               >
                 {tab.label} ({tab.count})
-              </button>
+              </Button>
             ))}
           </div>
 
@@ -527,7 +527,7 @@ const CronHealthWidget: React.FC<CronHealthWidgetProps> = ({ width, height, conf
               const isSelected = selectedJobId === job.id;
 
               return (
-                <button
+                <Button type="button" variant="ghost" size="none"
                   key={job.id}
                   onClick={() => setSelectedJobId(job.id)}
                   className={`w-full text-left flex items-center gap-3 p-3 border-b border-border/30 transition-colors hover:bg-accent ${isSelected ? 'bg-accent' : ''}`}
@@ -544,7 +544,7 @@ const CronHealthWidget: React.FC<CronHealthWidgetProps> = ({ width, height, conf
                       {job.message || statusDisplay.label}
                     </div>
                   </div>
-                </button>
+                </Button>
               );
             })}
             {filteredJobs.length === 0 && (

--- a/src/components/widgets/FavaWidget/index.tsx
+++ b/src/components/widgets/FavaWidget/index.tsx
@@ -292,7 +292,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
 
     return (
       <div key={node.account}>
-        <button
+        <Button type="button" variant="ghost" size="none"
           onClick={() => {
             if (hasChildren && depth < maxDepth) toggleExpanded(node.account);
             setSelectedAccount(node.account);
@@ -317,7 +317,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
           <span className={`shrink-0 ml-2 font-mono text-xs ${total < 0 ? 'text-red-500' : 'text-foreground'}`}>
             {formatCurrency(total)}
           </span>
-        </button>
+        </Button>
         {hasChildren && isExpanded && depth < maxDepth && (
           <div>
             {node.children
@@ -387,14 +387,14 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
           const name = account.account.split(':').pop() || account.account;
           const total = getTotal(account.balance_children);
           return (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={account.account}
               onClick={() => openFava()}
               className="flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1.5 text-foreground transition-colors hover:bg-accent"
             >
               <span className="max-w-[6rem] truncate">{name}</span>
               <span className="font-mono text-[11px] text-muted-foreground">{formatCurrency(total, true)}</span>
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -591,7 +591,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
                             const name = child.account.split(':').pop() || child.account;
                             const total = getTotal(child.balance_children);
                             return (
-                              <button
+                              <Button type="button" variant="ghost" size="none"
                                 key={child.account}
                                 onClick={() => setSelectedAccount(child.account)}
                                 className="w-full flex items-center justify-between text-xs py-1 px-1.5 rounded hover:bg-accent/50"
@@ -600,7 +600,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
                                 <span className={`shrink-0 ml-2 font-mono ${total < 0 ? 'text-red-500' : ''}`}>
                                   {formatCurrency(total)}
                                 </span>
-                              </button>
+                              </Button>
                             );
                           })}
                       </div>
@@ -687,7 +687,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
         {/* Tab bar */}
         <div className="flex border-b border-border/50 px-2">
           {tabs.map(tab => (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={tab.id}
               className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
                 activeTab === tab.id
@@ -698,7 +698,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
             >
               {tab.icon}
               {tab.label}
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -730,7 +730,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
                       const total = getTotal(acctNode.balance_children);
                       const isSelected = selectedAccount === acctNode.account;
                       return (
-                        <button
+                        <Button type="button" variant="ghost" size="none"
                           key={acctNode.account}
                           onClick={() => setSelectedAccount(acctNode.account)}
                           className={`w-full flex items-center justify-between py-1.5 px-3 text-sm hover:bg-accent/50 ${
@@ -744,7 +744,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
                           <span className={`shrink-0 ml-2 font-mono text-xs ${total < 0 ? 'text-red-500' : ''}`}>
                             {formatCurrency(total)}
                           </span>
-                        </button>
+                        </Button>
                       );
                     })}
                   </div>
@@ -824,7 +824,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
                           const total = getTotal(child.balance_children);
                           const childCount = child.children.length;
                           return (
-                            <button
+                            <Button type="button" variant="ghost" size="none"
                               key={child.account}
                               onClick={() => {
                                 setSelectedAccount(child.account);
@@ -844,7 +844,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
                                 </span>
                                 <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />
                               </div>
-                            </button>
+                            </Button>
                           );
                         })}
                     </div>

--- a/src/components/widgets/GeographyQuizWidget/index.tsx
+++ b/src/components/widgets/GeographyQuizWidget/index.tsx
@@ -281,7 +281,7 @@ const GeographyQuizWidget: React.FC<GeographyQuizWidgetProps> = ({ width, height
 
   // Shared: answer option button
   const renderOption = (option: string, compact = false) => (
-    <button
+    <Button type="button" variant="ghost" size="none"
       key={option}
       onClick={() => handleAnswerSelect(option)}
       disabled={selectedAnswer !== null || readOnly}
@@ -300,7 +300,7 @@ const GeographyQuizWidget: React.FC<GeographyQuizWidgetProps> = ({ width, height
         )}
         <span className="truncate">{option}</span>
       </div>
-    </button>
+    </Button>
   );
 
   // Shared: idle state (no quiz active)
@@ -665,7 +665,7 @@ const GeographyQuizWidget: React.FC<GeographyQuizWidgetProps> = ({ width, height
         </div>
         <div className="grid grid-cols-2 gap-3">
           {currentQuestion?.options.map(opt => (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={opt}
               onClick={() => handleAnswerSelect(opt)}
               disabled={selectedAnswer !== null || readOnly}
@@ -684,7 +684,7 @@ const GeographyQuizWidget: React.FC<GeographyQuizWidgetProps> = ({ width, height
                 )}
                 <span>{opt}</span>
               </div>
-            </button>
+            </Button>
           ))}
         </div>
       </div>

--- a/src/components/widgets/HabitWidget/index.tsx
+++ b/src/components/widgets/HabitWidget/index.tsx
@@ -287,7 +287,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
         {habits.map(habit => {
           const done = isCompletedOn(habit, todayStr);
           return (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={habit.id}
               onClick={() => !readOnly && toggleCompletion(habit.id, todayStr)}
               className={`flex shrink-0 items-center gap-1 rounded-full px-2.5 py-1 transition-colors ${
@@ -304,7 +304,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
               }`}>
                 {habit.name}
               </span>
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -324,7 +324,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
             const done = isCompletedOn(habit, todayStr);
             const streak = calculateStreak(habit);
             return (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 key={habit.id}
                 onClick={() => !readOnly && toggleCompletion(habit.id, todayStr)}
                 className={`w-full flex items-center gap-1.5 rounded px-1.5 py-1 text-left transition-colors ${
@@ -348,7 +348,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                     {streak}
                   </span>
                 )}
-              </button>
+              </Button>
             );
           })}
         </div>
@@ -420,7 +420,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                   {weekDays.map(({ dateStr, dayName, isToday }) => {
                     const completed = isCompletedOn(habit, dateStr);
                     return (
-                      <button
+                      <Button type="button" variant="ghost" size="none"
                         key={dateStr}
                         onClick={() => !readOnly && toggleCompletion(habit.id, dateStr)}
                         className={`
@@ -440,7 +440,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                         <span className="mt-0.5">
                           {completed ? <Check className="w-3 h-3" /> : '\u00B7'}
                         </span>
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>
@@ -514,7 +514,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-1.5 min-w-0 flex-1">
                     {/* Today toggle */}
-                    <button
+                    <Button type="button" variant="ghost" size="none"
                       onClick={() => !readOnly && toggleCompletion(habit.id, todayStr)}
                       className={`h-5 w-5 shrink-0 rounded border flex items-center justify-center transition-colors ${
                         isCompletedOn(habit, todayStr)
@@ -523,7 +523,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                       }`}
                     >
                       {isCompletedOn(habit, todayStr) && <Check className="h-3 w-3 text-white" />}
-                    </button>
+                    </Button>
                     <span className={`text-sm font-medium truncate ${
                       isCompletedOn(habit, todayStr) ? 'text-muted-foreground' : 'text-foreground'
                     }`}>
@@ -595,7 +595,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
               }`}
               onClick={() => setSelectedHabitId(habit.id)}
             >
-              <button
+              <Button type="button" variant="ghost" size="none"
                 onClick={(e) => { e.stopPropagation(); if (!readOnly) toggleCompletion(habit.id, todayStr); }}
                 className={`h-6 w-6 shrink-0 rounded-md border-2 flex items-center justify-center transition-colors ${
                   done
@@ -604,7 +604,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                 }`}
               >
                 {done && <Check className="h-4 w-4 text-white" />}
-              </button>
+              </Button>
               <div className="flex-1 min-w-0">
                 <span className={`text-sm font-medium ${done ? 'text-muted-foreground line-through' : 'text-foreground'}`}>
                   {habit.name}
@@ -660,7 +660,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                   {extendedDays.map(({ dateStr, isToday }) => {
                     const completed = isCompletedOn(habit, dateStr);
                     return (
-                      <button
+                      <Button type="button" variant="ghost" size="none"
                         key={dateStr}
                         onClick={(e) => { e.stopPropagation(); if (!readOnly) toggleCompletion(habit.id, dateStr); }}
                         className={`flex-1 h-7 rounded flex items-center justify-center transition-colors ${
@@ -674,7 +674,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                         } ${readOnly ? '' : 'hover:opacity-80'}`}
                       >
                         {completed && <Check className="h-3.5 w-3.5" />}
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>
@@ -822,7 +822,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
               {getWeekDays(3).map(({ dateStr, dayName, isToday }) => {
                 const completed = isCompletedOn(selectedHabit, dateStr);
                 return (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={dateStr}
                     onClick={() => !readOnly && toggleCompletion(selectedHabit.id, dateStr)}
                     className={`flex-1 flex flex-col items-center rounded-lg py-2 transition-colors ${
@@ -833,7 +833,7 @@ const HabitWidget: React.FC<HabitWidgetProps> = ({ width = 2, height = 2, config
                   >
                     <span className="text-xs font-medium">{dayName}</span>
                     <span className="mt-1">{completed ? <Check className="h-4 w-4" /> : '\u00B7'}</span>
-                  </button>
+                  </Button>
                 );
               })}
             </div>

--- a/src/components/widgets/HealthchecksWidget/index.tsx
+++ b/src/components/widgets/HealthchecksWidget/index.tsx
@@ -368,9 +368,8 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
     const StatusIcon = statusStyle.icon;
 
     return (
-      <button
+      <Button type="button" variant="ghost" size="none"
         key={check.slug}
-        type="button"
         onClick={() => setSelectedCheckSlug(check.slug)}
         className={cn(
           'w-full rounded-lg border border-border/60 bg-background/40 text-left transition-colors hover:bg-accent/50',
@@ -407,7 +406,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
             )}
           </div>
         </div>
-      </button>
+      </Button>
     );
   };
 

--- a/src/components/widgets/IframeWidget/index.tsx
+++ b/src/components/widgets/IframeWidget/index.tsx
@@ -20,6 +20,7 @@ import {
 import { Input } from '../../ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
+import { Slider } from '../../ui/slider';
 import WidgetHeader from '../common/WidgetHeader';
 import type { IframeWidgetConfig, IframeWidgetProps } from './types';
 import { cn } from '@/lib/utils';
@@ -545,17 +546,17 @@ const IframeWidget: React.FC<IframeWidgetProps> = ({ width, height, config }) =>
                 <Label htmlFor="iframe-scale">
                   Scale ({Math.round((localConfig.scale || 1) * 100)}%)
                 </Label>
-                <input
-                  id="iframe-scale"
-                  type="range"
-                  min="0.5"
-                  max="1.5"
-                  step="0.1"
-                  value={localConfig.scale || 1}
-                  onChange={(e) =>
-                    setLocalConfig(prev => ({ ...prev, scale: parseFloat(e.target.value) }))
-                  }
-                  className="w-full h-2 bg-secondary rounded-lg appearance-none cursor-pointer"
+                <Slider
+                  min={0.5}
+                  max={1.5}
+                  step={0.1}
+                  value={[localConfig.scale || 1]}
+                  onValueChange={([value]) => {
+                    if (typeof value === 'number') {
+                      setLocalConfig(prev => ({ ...prev, scale: value }));
+                    }
+                  }}
+                  className="mt-3"
                 />
                 <p className="text-xs text-muted-foreground mt-1">
                   Adjust to fit content within widget

--- a/src/components/widgets/JellyfinWidget/index.tsx
+++ b/src/components/widgets/JellyfinWidget/index.tsx
@@ -504,13 +504,13 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
           {activeSessions.slice(0, 2).map(s => renderSessionCard(s, true))}
         </div>
       ) : (
-        <button
+        <Button type="button" variant="ghost" size="none"
           onClick={openJellyfin}
           className="flex-1 flex flex-col items-center justify-center gap-1 rounded-lg hover:bg-accent transition-colors"
         >
           <Film className="w-6 h-6 text-purple-500" />
           <span className="text-xs text-muted-foreground">Nothing playing</span>
-        </button>
+        </Button>
       )}
       {recentItems.length > 0 && (
         <div className="text-[10px] text-muted-foreground text-center">
@@ -607,12 +607,12 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
 
     return (
       <div className="p-4 space-y-4">
-        <button
+        <Button type="button" variant="ghost" size="none"
           className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
           onClick={() => setSelectedItem(null)}
         >
           <ArrowLeft className="w-3 h-3" /> Back
-        </button>
+        </Button>
 
         <div className="flex gap-4">
           {imgUrl ? (
@@ -691,7 +691,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
               ].map(tab => {
                 const TabIcon = tab.icon;
                 return (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={tab.id}
                     className={`flex-1 flex items-center justify-center gap-1.5 px-2 py-2 text-xs transition-colors ${
                       activeTab === tab.id
@@ -711,7 +711,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                         {activeSessions.length}
                       </span>
                     )}
-                  </button>
+                  </Button>
                 );
               })}
             </div>
@@ -726,7 +726,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                 </div>
               ) : searchResults.length > 0 ? (
                 searchResults.map(item => (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={item.Id}
                     className={`w-full text-left px-3 py-2 hover:bg-accent transition-colors border-b border-border/50 ${
                       selectedItem?.Id === item.Id ? 'bg-accent' : ''
@@ -740,7 +740,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                         <div className="text-xs text-muted-foreground">{item.Type} {item.ProductionYear ? `\u00B7 ${item.ProductionYear}` : ''}</div>
                       </div>
                     </div>
-                  </button>
+                  </Button>
                 ))
               ) : (
                 <div className="flex items-center justify-center h-20 text-sm text-muted-foreground">
@@ -750,7 +750,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
             ) : activeTab === 'playing' ? (
               activeSessions.length > 0 ? (
                 activeSessions.map(session => (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={session.Id}
                     className={`w-full text-left px-3 py-2 hover:bg-accent transition-colors border-b border-border/50 ${
                       selectedItem?.Id === session.NowPlayingItem?.Id ? 'bg-accent' : ''
@@ -772,7 +772,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                         </div>
                       </div>
                     </div>
-                  </button>
+                  </Button>
                 ))
               ) : (
                 <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
@@ -783,7 +783,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
             ) : activeTab === 'recent' ? (
               recentItems.length > 0 ? (
                 recentItems.map(item => (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={item.Id}
                     className={`w-full text-left px-3 py-2 hover:bg-accent transition-colors border-b border-border/50 ${
                       selectedItem?.Id === item.Id ? 'bg-accent' : ''
@@ -799,7 +799,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                         </div>
                       </div>
                     </div>
-                  </button>
+                  </Button>
                 ))
               ) : (
                 <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
@@ -809,7 +809,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
             ) : /* libraries tab */ (
               selectedLibrary ? (
                 <>
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     className="w-full text-left px-3 py-2 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 border-b border-border"
                     onClick={() => {
                       setSelectedLibrary(null);
@@ -818,9 +818,9 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                     }}
                   >
                     <ArrowLeft className="w-3 h-3" /> All Libraries
-                  </button>
+                  </Button>
                   {libraryItems.map(item => (
-                    <button
+                    <Button type="button" variant="ghost" size="none"
                       key={item.Id}
                       className={`w-full text-left px-3 py-2 hover:bg-accent transition-colors border-b border-border/50 ${
                         selectedItem?.Id === item.Id ? 'bg-accent' : ''
@@ -834,12 +834,12 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                           <div className="text-xs text-muted-foreground">{item.ProductionYear || item.Type}</div>
                         </div>
                       </div>
-                    </button>
+                    </Button>
                   ))}
                 </>
               ) : (
                 libraries.map(lib => (
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     key={lib.ItemId}
                     className="w-full text-left px-3 py-3 hover:bg-accent transition-colors border-b border-border/50 flex items-center gap-3"
                     onClick={() => setSelectedLibrary(lib)}
@@ -851,7 +851,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
                         {lib.CollectionType || 'mixed'}
                       </div>
                     </div>
-                  </button>
+                  </Button>
                 ))
               )
             )}

--- a/src/components/widgets/KumaWidget/index.tsx
+++ b/src/components/widgets/KumaWidget/index.tsx
@@ -354,9 +354,8 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
     const StatusIcon = statusStyle.icon;
 
     return (
-      <button
+      <Button type="button" variant="ghost" size="none"
         key={monitor.id}
-        type="button"
         onClick={() => setSelectedMonitorId(monitor.id)}
         className={cn(
           'w-full rounded-lg border border-border/60 bg-background/40 text-left transition-colors hover:bg-accent/50',
@@ -393,7 +392,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
             )}
           </div>
         </div>
-      </button>
+      </Button>
     );
   };
 

--- a/src/components/widgets/NotesWidget/index.tsx
+++ b/src/components/widgets/NotesWidget/index.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
+import { Textarea } from '@/components/ui/textarea';
 import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../common/WidgetSettingsDialog';
 import { WidgetShell } from '../common/WidgetShell';
 import { NotesWidgetProps, NotesWidgetConfig } from './types';
@@ -192,12 +193,12 @@ const NotesWidget: React.FC<NotesWidgetProps> = ({ width = 2, height = 2, config
           backgroundColor: 'transparent'
         }}
       >
-        <textarea
+        <Textarea
           ref={textareaRef}
           value={localConfig.content || ''}
           onChange={handleContentChange}
           readOnly={readOnly}
-          className="w-full h-full resize-none border-none focus:outline-none focus:ring-0 bg-transparent
+          className="h-full min-h-0 resize-none border-none bg-transparent shadow-none focus-visible:ring-0
                     text-foreground py-1 leading-relaxed placeholder-muted-foreground"
           style={{
             fontFamily: localConfig.fontFamily || defaultConfig.fontFamily,

--- a/src/components/widgets/OllamaWidget/index.tsx
+++ b/src/components/widgets/OllamaWidget/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
+import { Textarea } from '../../ui/textarea';
 import {
   Select,
   SelectContent,
@@ -597,9 +598,10 @@ const OllamaWidget: React.FC<OllamaWidgetProps> = ({ width, height, config }) =>
           {/* System prompt editor (inline in app mode) */}
           {!readOnly && (
             <div className="p-3 border-b space-y-2">
-              <label className="text-xs font-medium text-foreground">System Prompt</label>
-              <textarea
-                className="w-full h-20 px-2 py-1.5 text-xs border rounded-md resize-none bg-transparent focus:outline-none focus:ring-2 focus:ring-ring"
+              <Label htmlFor="ollama-system-prompt-inline" className="text-xs">System Prompt</Label>
+              <Textarea
+                id="ollama-system-prompt-inline"
+                className="h-20 resize-none px-2 py-1.5 text-xs"
                 value={localConfig.systemPrompt || ''}
                 onChange={(e) => {
                   const updated = { ...localConfig, systemPrompt: e.target.value };
@@ -797,9 +799,9 @@ const OllamaWidget: React.FC<OllamaWidgetProps> = ({ width, height, config }) =>
 
             <div>
               <Label htmlFor="system-prompt">System Prompt (optional)</Label>
-              <textarea
+              <Textarea
                 id="system-prompt"
-                className="w-full h-24 px-3 py-2 text-sm border rounded-md resize-none bg-transparent focus:outline-none focus:ring-2 focus:ring-ring"
+                className="h-24 resize-none"
                 value={localConfig.systemPrompt || ''}
                 onChange={(e) =>
                   setLocalConfig(prev => ({ ...prev, systemPrompt: e.target.value }))

--- a/src/components/widgets/PaisaWidget/index.tsx
+++ b/src/components/widgets/PaisaWidget/index.tsx
@@ -537,12 +537,12 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
               </div>
             </div>
             {!readOnly && (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 onClick={fetchData}
                 className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent rounded-full transition-colors"
               >
                 <RefreshCw className="h-3.5 w-3.5" />
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -683,12 +683,12 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
               </div>
             ))}
             {!readOnly && (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 onClick={fetchData}
                 className="p-2 text-muted-foreground hover:text-foreground hover:bg-accent rounded-full transition-colors"
               >
                 <RefreshCw className="h-4 w-4" />
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -696,7 +696,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
         {/* Tab navigation */}
         <div className="flex border-b border-border/50 px-4">
           {tabs.map(tab => (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={tab.key}
               className={`flex items-center gap-1.5 px-3 py-2 text-sm transition-colors ${
                 activeTab === tab.key
@@ -707,7 +707,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
             >
               {tab.icon}
               {tab.label}
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -798,7 +798,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
         </div>
         <div className="space-y-2">
           {assetCategories.map((cat, i) => (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={cat.key}
               onClick={() => { setSelectedCategory(cat.key); setActiveTab('assets'); }}
               className="w-full text-left rounded-lg border border-border/50 p-3 hover:bg-accent/50 transition-colors"
@@ -816,7 +816,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
                 {cat.gainAmount >= 0 ? '+' : ''}{formatCurrency(cat.gainAmount, true)} gain
                 {cat.xirr ? ` · ${(cat.xirr * 100).toFixed(1)}% XIRR` : ''}
               </div>
-            </button>
+            </Button>
           ))}
         </div>
       </div>
@@ -852,14 +852,14 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
         {/* Left: category list */}
         <div className="w-1/3 border-r border-border/50 overflow-y-auto">
           <div className="p-2 border-b border-border/50">
-            <button
+            <Button type="button" variant="ghost" size="none"
               onClick={() => setSelectedCategory(null)}
               className={`w-full text-left px-3 py-2 text-sm rounded-lg transition-colors ${
                 !selectedCategory ? 'bg-accent font-medium' : 'hover:bg-accent/50'
               }`}
             >
               All Assets
-            </button>
+            </Button>
           </div>
           {assetCategories.map((cat, i) => (
             <div
@@ -938,7 +938,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
                 {assetCategories.map((cat, i) => {
                   const percentage = totalNetworth > 0 ? (cat.amount / totalNetworth) * 100 : 0;
                   return (
-                    <button
+                    <Button type="button" variant="ghost" size="none"
                       key={cat.key}
                       onClick={() => setSelectedCategory(cat.key)}
                       className="text-left rounded-lg border border-border/50 p-4 hover:bg-accent/50 transition-colors"
@@ -956,7 +956,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
                           {cat.gainAmount >= 0 ? '+' : ''}{formatCurrency(cat.gainAmount, true)}
                         </span>
                       </div>
-                    </button>
+                    </Button>
                   );
                 })}
               </div>

--- a/src/components/widgets/PomodoroWidget/index.tsx
+++ b/src/components/widgets/PomodoroWidget/index.tsx
@@ -405,7 +405,7 @@ const PomodoroWidget: React.FC<PomodoroWidgetProps> = ({ width, height, config }
               >
                 <RotateCcw size={20} />
               </Button>
-              <button
+              <Button type="button" variant="ghost" size="none"
                 className={`rounded-full p-5 text-white transition-colors ${
                   mode === TimerMode.WORK
                     ? 'bg-red-500 hover:bg-red-600'
@@ -417,7 +417,7 @@ const PomodoroWidget: React.FC<PomodoroWidgetProps> = ({ width, height, config }
                 aria-label={isActive ? 'Pause' : 'Start'}
               >
                 {isActive ? <Pause size={28} /> : <Play size={28} />}
-              </button>
+              </Button>
               <Button
                 variant="secondary"
                 size="icon"

--- a/src/components/widgets/QRCodeWidget/index.tsx
+++ b/src/components/widgets/QRCodeWidget/index.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -428,9 +429,11 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
                 </p>
                 <div className="space-y-1">
                   {history.slice(0, 5).map(item => (
-                    <button
+                    <Button
                       key={item.id}
-                      className="w-full text-left text-xs text-muted-foreground hover:text-foreground truncate block py-0.5 hover:bg-accent rounded px-1 transition-colors"
+                      type="button"
+                      variant="ghost"
+                      className="h-auto w-full justify-start truncate px-1 py-0.5 text-xs font-normal text-muted-foreground hover:text-foreground"
                       onClick={() => {
                         if (!readOnly) {
                           updateConfig({ content: item.content });
@@ -439,7 +442,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
                       title={item.content}
                     >
                       {item.label || item.content}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>
@@ -610,7 +613,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
                 {!readOnly && (
                   <div className="mt-4 flex items-center gap-4 text-xs text-muted-foreground">
                     <div className="flex items-center gap-1.5">
-                      <label htmlFor="app-fg" className="cursor-pointer">Color:</label>
+                      <Label htmlFor="app-fg" className="cursor-pointer text-xs text-muted-foreground">Color:</Label>
                       <input
                         id="app-fg"
                         type="color"
@@ -620,7 +623,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
                       />
                     </div>
                     <div className="flex items-center gap-1.5">
-                      <label htmlFor="app-bg" className="cursor-pointer">Background:</label>
+                      <Label htmlFor="app-bg" className="cursor-pointer text-xs text-muted-foreground">Background:</Label>
                       <input
                         id="app-bg"
                         type="color"
@@ -690,7 +693,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
 
             <div>
               <Label htmlFor="settings-content">Content (URL or text)</Label>
-              <textarea
+              <Textarea
                 id="settings-content"
                 placeholder="https://example.com or any text"
                 value={localConfig.content || ''}
@@ -698,7 +701,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
                   setLocalConfig(prev => ({ ...prev, content: e.target.value }))
                 }
                 rows={4}
-                className="flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                className="min-h-[80px]"
               />
               <p className="text-xs text-muted-foreground mt-1">
                 Enter a URL, text, phone number, or any content to encode

--- a/src/components/widgets/RSSWidget/index.tsx
+++ b/src/components/widgets/RSSWidget/index.tsx
@@ -14,6 +14,14 @@ import type { RSSWidgetProps } from './types';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { Button } from '../../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '../../ui/dropdown-menu';
 import { Switch } from '../../ui/switch';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../../ui/tabs';
 import sanitizeHtml from 'sanitize-html';
@@ -94,12 +102,10 @@ export const RSSWidget: React.FC<RSSWidgetProps> = ({ config, width, height }) =
   // App mode state
   const [selectedArticleIndex, setSelectedArticleIndex] = useState<number | null>(null);
   const [appFeedFilter, setAppFeedFilter] = useState<string>('all');
-  const [showFeedFilterDropdown, setShowFeedFilterDropdown] = useState(false);
   const [readerContentByLink, setReaderContentByLink] = useState<Record<string, RSSReaderContentState>>({});
 
   // Refs for the widget container
   const widgetRef = useRef<HTMLDivElement | null>(null);
-  const feedFilterRef = useRef<HTMLDivElement | null>(null);
   const readerContentByLinkRef = useRef<Record<string, RSSReaderContentState>>({});
 
 
@@ -237,19 +243,6 @@ export const RSSWidget: React.FC<RSSWidgetProps> = ({ config, width, height }) =
     refreshInterval: 900000, // Refresh every 15 minutes
     enabled: localConfig.feeds?.some(feed => feed.enabled) ?? false
   });
-
-  // Close feed filter dropdown on outside click
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (feedFilterRef.current && !feedFilterRef.current.contains(event.target as Node)) {
-        setShowFeedFilterDropdown(false);
-      }
-    };
-    if (showFeedFilterDropdown) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [showFeedFilterDropdown]);
 
   useEffect(() => {
     readerContentByLinkRef.current = readerContentByLink;
@@ -656,36 +649,41 @@ export const RSSWidget: React.FC<RSSWidgetProps> = ({ config, width, height }) =
           </div>
           <div className="flex items-center gap-3">
             {/* Feed filter dropdown */}
-            <div className="relative" ref={feedFilterRef}>
-              <button
-                onClick={() => setShowFeedFilterDropdown(!showFeedFilterDropdown)}
-                className="flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs text-muted-foreground hover:bg-accent transition-colors"
-              >
-                <span className="max-w-[140px] truncate">
-                  {appFeedFilter === 'all' ? 'All Feeds' : appFeedFilter}
-                </span>
-                <ChevronDown size={12} />
-              </button>
-              {showFeedFilterDropdown && (
-                <div className="absolute right-0 top-full mt-1 z-50 w-48 rounded-md border border-border bg-background shadow-lg py-1">
-                  <button
-                    onClick={() => { setAppFeedFilter('all'); setShowFeedFilterDropdown(false); setSelectedArticleIndex(null); }}
-                    className={`w-full text-left px-3 py-1.5 text-xs hover:bg-accent transition-colors ${appFeedFilter === 'all' ? 'font-semibold text-foreground' : 'text-foreground'}`}
-                  >
-                    All Feeds
-                  </button>
-                  {uniqueFeedTitles.map(title => (
-                    <button
-                      key={title}
-                      onClick={() => { setAppFeedFilter(title); setShowFeedFilterDropdown(false); setSelectedArticleIndex(null); }}
-                      className={`w-full text-left px-3 py-1.5 text-xs hover:bg-accent transition-colors truncate ${appFeedFilter === title ? 'font-semibold text-foreground' : 'text-foreground'}`}
-                    >
-                      {title}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1.5 px-2.5 text-xs text-muted-foreground"
+                >
+                  <span className="max-w-[140px] truncate">
+                    {appFeedFilter === 'all' ? 'All Feeds' : appFeedFilter}
+                  </span>
+                  <ChevronDown size={12} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuRadioGroup
+                  value={appFeedFilter}
+                  onValueChange={(value) => {
+                    setAppFeedFilter(value);
+                    setSelectedArticleIndex(null);
+                  }}
+                >
+                  <DropdownMenuGroup>
+                    <DropdownMenuRadioItem value="all" className="text-xs">
+                      <span className="truncate">All Feeds</span>
+                    </DropdownMenuRadioItem>
+                    {uniqueFeedTitles.map(title => (
+                      <DropdownMenuRadioItem key={title} value={title} className="text-xs">
+                        <span className="truncate">{title}</span>
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuGroup>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
             {/* Article count */}
             <span className="text-xs text-muted-foreground">
               {filteredFeedItems.length} article{filteredFeedItems.length !== 1 ? 's' : ''}
@@ -713,10 +711,12 @@ export const RSSWidget: React.FC<RSSWidgetProps> = ({ config, width, height }) =
           {/* Left sidebar: Article list */}
           <div className="w-1/3 border-r border-border overflow-y-auto">
 	            {filteredFeedItems.map((item, index) => (
-              <button
+              <Button
                 key={`${item.link}-${index}`}
+                type="button"
+                variant="ghost"
                 onClick={() => setSelectedArticleIndex(index)}
-                className={`w-full text-left px-3 py-2.5 border-b border-border transition-colors ${
+                className={`h-auto w-full justify-start rounded-none border-b border-border px-3 py-2.5 text-left transition-colors ${
                   selectedArticleIndex === index
                     ? 'bg-accent border-l-2 border-l-border'
                     : 'hover:bg-accent'
@@ -737,7 +737,7 @@ export const RSSWidget: React.FC<RSSWidgetProps> = ({ config, width, height }) =
                     </span>
                   )}
                 </div>
-              </button>
+              </Button>
             ))}
           </div>
 

--- a/src/components/widgets/ReadwiseWidget/index.tsx
+++ b/src/components/widgets/ReadwiseWidget/index.tsx
@@ -376,7 +376,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
           {highlightCount || highlights.length} highlights
         </span>
         {previewHighlights.map(h => (
-          <button
+          <Button type="button" variant="ghost" size="none"
             key={h.id}
             onClick={() => openHighlightInReadwise(h.id)}
             className="flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1.5 text-foreground transition-colors hover:bg-accent"
@@ -384,7 +384,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
           >
             <Quote className="h-3 w-3 shrink-0 text-muted-foreground" />
             <span className="max-w-[10rem] truncate italic">{h.text}</span>
-          </button>
+          </Button>
         ))}
       </div>
     );
@@ -525,7 +525,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
             )}
           </div>
           {highlights.map(h => (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={h.id}
               className={`w-full text-left p-2.5 border-b border-border/50 transition-colors hover:bg-accent ${
                 displayHighlight?.id === h.id ? 'bg-accent' : ''
@@ -540,7 +540,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
                   {h.book_title}
                 </p>
               )}
-            </button>
+            </Button>
           ))}
         </div>
 
@@ -634,17 +634,17 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
           </div>
 
           <div className="flex-1 overflow-y-auto">
-            <button
+            <Button type="button" variant="ghost" size="none"
               className={`w-full text-left px-3 py-2 text-xs transition-colors hover:bg-accent ${
                 selectedBookFilter === null ? 'bg-accent font-medium' : ''
               }`}
               onClick={() => setSelectedBookFilter(null)}
             >
               All highlights ({highlights.length})
-            </button>
+            </Button>
 
             {bookList.map(book => (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 key={book.id}
                 className={`w-full text-left px-3 py-2 text-xs transition-colors hover:bg-accent flex items-center justify-between ${
                   selectedBookFilter === book.id ? 'bg-accent font-medium' : ''
@@ -653,7 +653,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
               >
                 <span className="truncate">{book.title}</span>
                 <span className="shrink-0 ml-2 text-muted-foreground">{book.count}</span>
-              </button>
+              </Button>
             ))}
           </div>
 
@@ -693,7 +693,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
               </div>
             ) : (
               filteredHighlights.map(h => (
-                <button
+                <Button type="button" variant="ghost" size="none"
                   key={h.id}
                   className={`w-full text-left p-3 border-b border-border/50 transition-colors hover:bg-accent ${
                     displayHighlight?.id === h.id ? 'bg-accent' : ''
@@ -716,7 +716,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
                       </div>
                     )}
                   </div>
-                </button>
+                </Button>
               ))
             )}
           </div>

--- a/src/components/widgets/ServicesWidget/index.tsx
+++ b/src/components/widgets/ServicesWidget/index.tsx
@@ -388,7 +388,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           const Icon = getIcon(service.icon);
           const status = serviceStatus[service.id];
           return (
-            <button
+            <Button type="button" variant="ghost" size="none"
               key={service.id}
               onClick={() => openService(service.url)}
               className="flex shrink-0 items-center gap-2 rounded-full border border-border bg-card px-2.5 py-1.5 text-foreground transition-colors hover:bg-accent"
@@ -398,7 +398,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
               )}
               <Icon className="h-3.5 w-3.5" />
               <span className="max-w-[8rem] truncate">{service.name}</span>
-            </button>
+            </Button>
           );
         })}
       </div>
@@ -411,7 +411,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     const status = serviceStatus[service.id];
 
     return (
-      <button
+      <Button type="button" variant="ghost" size="none"
         key={service.id}
         onClick={() => openService(service.url)}
         className="relative flex flex-col items-center justify-center gap-2 rounded-xl border border-border bg-muted/30 p-2 transition-colors hover:bg-accent"
@@ -422,7 +422,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
         )}
         <Icon className="h-6 w-6 text-foreground" />
         <span className="w-full truncate text-center text-xs font-medium text-foreground">{service.name}</span>
-      </button>
+      </Button>
     );
   };
 
@@ -434,7 +434,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     const StatusIcon = getStatusIcon(status);
 
     return (
-      <button
+      <Button type="button" variant="ghost" size="none"
         key={service.id}
         onClick={() => openService(service.url)}
         className="group flex h-full min-h-[112px] flex-col justify-between rounded-xl border border-border bg-muted/30 p-4 text-left transition-colors hover:bg-accent"
@@ -480,7 +480,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           </div>
           <ArrowUpRight className="h-3.5 w-3.5 flex-shrink-0 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
         </div>
-      </button>
+      </Button>
     );
   };
 
@@ -573,7 +573,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
         <div className="flex flex-1 overflow-hidden">
           {/* Category sidebar */}
           <div className="w-36 shrink-0 border-r border-border overflow-y-auto">
-            <button
+            <Button type="button" variant="ghost" size="none"
               onClick={() => setSelectedCategory(null)}
               className={cn(
                 'w-full px-3 py-2 text-left text-xs transition-colors hover:bg-accent',
@@ -581,11 +581,11 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
               )}
             >
               All ({localConfig.services.length})
-            </button>
+            </Button>
             {categories.map(cat => {
               const count = localConfig.services.filter(s => s.category === cat).length;
               return (
-                <button
+                <Button type="button" variant="ghost" size="none"
                   key={cat}
                   onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
                   className={cn(
@@ -594,7 +594,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
                   )}
                 >
                   {cat} ({count})
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -642,7 +642,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
 
           {/* Category filter tabs */}
           <div className="flex items-center gap-1 overflow-x-auto px-2 py-1.5 border-b border-border">
-            <button
+            <Button type="button" variant="ghost" size="none"
               onClick={() => setSelectedCategory(null)}
               className={cn(
                 'shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors',
@@ -652,9 +652,9 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
               )}
             >
               All
-            </button>
+            </Button>
             {categories.map(cat => (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 key={cat}
                 onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
                 className={cn(
@@ -665,7 +665,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
                 )}
               >
                 {cat}
-              </button>
+              </Button>
             ))}
           </div>
 

--- a/src/components/widgets/TodoWidget/index.tsx
+++ b/src/components/widgets/TodoWidget/index.tsx
@@ -450,7 +450,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
               className="flex shrink-0 items-center gap-1 rounded-full bg-muted px-2.5 py-1"
             >
               {!readOnly && (
-                <button
+                <Button type="button" variant="ghost" size="none"
                   onClick={() => toggleTodo(item.id)}
                   className="h-3 w-3 shrink-0 rounded-full border border-border hover:border-green-400 transition-colors"
                   aria-label="Mark as complete"
@@ -499,7 +499,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
                   onDrop={(e) => handleDrop(e, item)}
                   className={`flex items-center p-1 rounded-md hover:bg-accent transition-all relative text-foreground group cursor-grab active:cursor-grabbing ${getDropZoneClass(item.id)}`}
                 >
-                  <button
+                  <Button type="button" variant="ghost" size="none"
                     onClick={() => !readOnly && toggleTodo(item.id)}
                     className={`flex-shrink-0 w-3 h-3 rounded-full border ${
                       item.completed
@@ -510,7 +510,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
                     disabled={readOnly}
                   >
                     {item.completed && <Check size={8} />}
-                  </button>
+                  </Button>
                   <span className={`text-xs font-medium flex-grow truncate ${
                     item.completed ? 'line-through text-muted-foreground' : ''
                   }`}>
@@ -518,13 +518,13 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
                   </span>
                   {!readOnly && (
                     <div className="flex items-center opacity-0 group-hover:opacity-100 transition-opacity ml-1">
-                      <button
+                      <Button type="button" variant="ghost" size="none"
                         onClick={() => deleteTodo(item.id)}
                         className="p-0.5 text-muted-foreground hover:text-destructive"
                         aria-label="Delete task"
                       >
                         <Trash2 size={10} />
-                      </button>
+                      </Button>
                     </div>
                   )}
                 </li>
@@ -568,7 +568,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
             </div>
           )}
 
-          <button
+          <Button type="button" variant="ghost" size="none"
             onClick={() => !readOnly && toggleTodo(item.id)}
             className={`flex-shrink-0 w-5 h-5 rounded-full border ${
               item.completed
@@ -579,7 +579,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
             disabled={readOnly}
           >
             {item.completed && <Check size={12} />}
-          </button>
+          </Button>
 
           <span
             className={`flex-grow truncate ${
@@ -591,13 +591,13 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
 
           {!readOnly && (
             <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-              <button
+              <Button type="button" variant="ghost" size="none"
                 onClick={() => deleteTodo(item.id)}
                 className="p-1 text-muted-foreground hover:text-destructive"
                 aria-label="Delete task"
               >
                 <Trash2 size={14} />
-              </button>
+              </Button>
             </div>
           )}
         </li>
@@ -840,7 +840,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
           </div>
         )}
 
-        <button
+        <Button type="button" variant="ghost" size="none"
           onClick={() => !readOnly && toggleTodo(item.id)}
           className={`flex-shrink-0 w-5 h-5 rounded-full border-2 transition-colors ${
             item.completed
@@ -851,7 +851,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
           disabled={readOnly}
         >
           {item.completed && <Check size={12} />}
-        </button>
+        </Button>
 
         {editingItemId === item.id ? (
           <form
@@ -891,7 +891,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
 
         {!readOnly && editingItemId !== item.id && (
           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            <button
+            <Button type="button" variant="ghost" size="none"
               onClick={() => {
                 setEditingItemId(item.id);
                 setEditingText(item.text);
@@ -900,14 +900,14 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
               aria-label="Edit task"
             >
               <Pencil size={14} />
-            </button>
-            <button
+            </Button>
+            <Button type="button" variant="ghost" size="none"
               onClick={() => deleteTodo(item.id)}
               className="p-1 text-muted-foreground hover:text-destructive"
               aria-label="Delete task"
             >
               <Trash2 size={14} />
-            </button>
+            </Button>
           </div>
         )}
       </li>
@@ -926,7 +926,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
 
           <nav className="space-y-1 flex-grow">
             {filterTabs.map((tab) => (
-              <button
+              <Button type="button" variant="ghost" size="none"
                 key={tab.key}
                 onClick={() => setAppFilter(tab.key)}
                 className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
@@ -943,7 +943,7 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
                 }`}>
                   {tab.count}
                 </span>
-              </button>
+              </Button>
             ))}
           </nav>
 
@@ -1036,13 +1036,13 @@ const TodoWidget: React.FC<TodoWidgetProps> = ({ width, height, config }) => {
                 {/* Completed items (collapsible) */}
                 {filteredCompleted.length > 0 && appFilter !== 'pending' && (
                   <div className="mt-4">
-                    <button
+                    <Button type="button" variant="ghost" size="none"
                       onClick={() => setShowCompletedSection(!showCompletedSection)}
                       className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground mb-2 transition-colors"
                     >
                       {showCompletedSection ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
                       <span>Completed ({filteredCompleted.length})</span>
-                    </button>
+                    </Button>
                     {showCompletedSection && (
                       <ul className="space-y-1">
                         {filteredCompleted.map(renderAppTodoItem)}

--- a/src/components/widgets/TodoistWidget/index.tsx
+++ b/src/components/widgets/TodoistWidget/index.tsx
@@ -140,7 +140,7 @@ const Task = memo(({
   return (
     <div className={`flex items-center ${compact ? 'gap-2 py-1 px-1' : 'gap-3 p-2'} hover:bg-accent rounded-lg group`}>
       {!readOnly && (
-        <button
+        <Button type="button" variant="ghost" size="none"
           onClick={() => onToggle(task.id, !task.completed)}
           className={`flex-shrink-0 ${compact ? 'w-4 h-4' : 'w-[18px] h-[18px]'} rounded-full border-2 ${
             task.completed
@@ -165,7 +165,7 @@ const Task = memo(({
               />
             </div>
           )}
-        </button>
+        </Button>
       )}
       {readOnly && (
         <div className={`flex-shrink-0 ${compact ? 'w-4 h-4' : 'w-[18px] h-[18px]'} rounded-full border-2 ${
@@ -702,7 +702,7 @@ const TodoistWidget: React.FC<TodoistWidgetProps> = ({ width, height, config }) 
           </div>
 
           <div className="flex-1 overflow-y-auto py-1">
-            <button
+            <Button type="button" variant="ghost" size="none"
               onClick={() => setSelectedProjectId(null)}
               className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
                 !selectedProjectId
@@ -713,13 +713,13 @@ const TodoistWidget: React.FC<TodoistWidgetProps> = ({ width, height, config }) 
               <Inbox className="w-4 h-4 flex-shrink-0" />
               <span className="truncate">All Tasks</span>
               <span className="ml-auto text-xs text-muted-foreground">{tasks.length}</span>
-            </button>
+            </Button>
 
             {projects.map(project => {
               const projectTaskCount = tasks.filter(t => t.project_id === project.id).length;
               if (projectTaskCount === 0) return null;
               return (
-                <button
+                <Button type="button" variant="ghost" size="none"
                   key={project.id}
                   onClick={() => setSelectedProjectId(project.id === selectedProjectId ? null : project.id)}
                   className={`w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors ${
@@ -731,7 +731,7 @@ const TodoistWidget: React.FC<TodoistWidgetProps> = ({ width, height, config }) 
                   <FolderOpen className="w-4 h-4 flex-shrink-0" />
                   <span className="truncate">{project.name}</span>
                   <span className="ml-auto text-xs text-muted-foreground">{projectTaskCount}</span>
-                </button>
+                </Button>
               );
             })}
           </div>
@@ -782,7 +782,7 @@ const TodoistWidget: React.FC<TodoistWidgetProps> = ({ width, height, config }) 
                       >
                         <div className="flex items-center gap-3 px-3 py-2 hover:bg-accent rounded-lg group">
                           {!readOnly ? (
-                            <button
+                            <Button type="button" variant="ghost" size="none"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 toggleTask(task.id, !task.completed);
@@ -797,7 +797,7 @@ const TodoistWidget: React.FC<TodoistWidgetProps> = ({ width, height, config }) 
                               {pendingTasks.has(task.id) && (
                                 <Loader2 className="w-3 h-3 animate-spin text-foreground" />
                               )}
-                            </button>
+                            </Button>
                           ) : (
                             <div className={`flex-shrink-0 w-[18px] h-[18px] rounded-full border-2 ${getPriorityBorder(task.priority)} flex items-center justify-center`} />
                           )}

--- a/src/components/widgets/WeatherWidget/index.tsx
+++ b/src/components/widgets/WeatherWidget/index.tsx
@@ -10,6 +10,7 @@ import { WidgetShell } from '../../widgets/common/WidgetShell';
 import { WeatherWidgetProps, WeatherData, WeatherWidgetConfig } from './types';
 import { Button } from '../../ui/button';
 import { Input } from '../../ui/input';
+import { Popover, PopoverAnchor, PopoverContent } from '../../ui/popover';
 import { faviconService } from '@/lib/services/favicon';
 
 interface CitySearchResult {
@@ -151,6 +152,7 @@ const WeatherWidget: FC<WeatherWidgetProps> = ({ width, height, config, refreshI
   const handleCitySearchChange = useCallback((value: string) => {
     setCitySearch(value);
     setLocationError(null);
+    setShowResults(value.trim().length >= 2);
 
     // Clear previous timeout
     if (searchTimeoutRef.current) {
@@ -1131,56 +1133,66 @@ const WeatherWidget: FC<WeatherWidgetProps> = ({ width, height, config, refreshI
     <>
       <div className="space-y-2">
         <Label htmlFor="location-input">Location</Label>
-        <div className="relative">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              id="location-input"
-              type="text"
-              placeholder="Search for a city..."
-              value={citySearch || localConfig.location || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                handleCitySearchChange(e.target.value);
-              }}
-              onFocus={() => {
-                if (cityResults.length > 0) setShowResults(true);
-              }}
-              className={`pl-9 ${locationError ? 'border-red-500' : ''}`}
-            />
-            {isSearching && (
-              <Loader2 className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
-            )}
-          </div>
+        <Popover
+          open={showResults && citySearch.length >= 2}
+          onOpenChange={(open) => {
+            if (!open) {
+              setShowResults(false);
+            }
+          }}
+        >
+          <PopoverAnchor asChild>
+            <div className="relative w-full">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="location-input"
+                type="text"
+                placeholder="Search for a city..."
+                value={citySearch || localConfig.location || ''}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                  handleCitySearchChange(e.target.value);
+                }}
+                onFocus={() => {
+                  if (citySearch.length >= 2 || cityResults.length > 0) {
+                    setShowResults(true);
+                  }
+                }}
+                className={`pl-9 ${locationError ? 'border-red-500' : ''}`}
+              />
+              {isSearching && (
+                <Loader2 className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+              )}
+            </div>
+          </PopoverAnchor>
 
-          {/* Search results dropdown */}
-          {showResults && cityResults.length > 0 && (
-            <div className="absolute z-50 w-full mt-1 bg-popover border rounded-md shadow-lg max-h-60 overflow-y-auto">
-              {cityResults.map((city) => (
-                <button
-                  key={city.id}
-                  type="button"
-                  className="w-full px-3 py-2 text-left hover:bg-accent flex items-start gap-2 border-b last:border-b-0"
-                  onClick={() => handleCitySelect(city)}
-                >
-                  <MapPin className="h-4 w-4 mt-0.5 text-muted-foreground flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium text-sm truncate">{city.name}</div>
-                    <div className="text-xs text-muted-foreground truncate">
-                      {city.admin1 ? `${city.admin1}, ` : ''}{city.country}
+          <PopoverContent align="start" className="w-[min(28rem,calc(100vw-4rem))] max-h-60 overflow-y-auto p-1">
+            {cityResults.length > 0 ? (
+              <div className="flex flex-col">
+                {cityResults.map((city) => (
+                  <Button
+                    key={city.id}
+                    type="button"
+                    variant="ghost"
+                    className="h-auto justify-start gap-2 rounded-sm px-3 py-2 text-left"
+                    onClick={() => handleCitySelect(city)}
+                  >
+                    <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium">{city.name}</div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {city.admin1 ? `${city.admin1}, ` : ''}{city.country}
+                      </div>
                     </div>
-                  </div>
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* No results message */}
-          {showResults && citySearch.length >= 2 && !isSearching && cityResults.length === 0 && (
-            <div className="absolute z-50 w-full mt-1 bg-popover border rounded-md shadow-lg p-3 text-sm text-muted-foreground">
-              No cities found for "{citySearch}"
-            </div>
-          )}
-        </div>
+                  </Button>
+                ))}
+              </div>
+            ) : (
+              <p className="px-3 py-2 text-sm text-muted-foreground">
+                No cities found for "{citySearch}"
+              </p>
+            )}
+          </PopoverContent>
+        </Popover>
         {locationError && (
           <p className="text-xs text-red-500">{locationError}</p>
         )}

--- a/src/components/widgets/YouTubeWidget/index.tsx
+++ b/src/components/widgets/YouTubeWidget/index.tsx
@@ -173,7 +173,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
       );
     }
     return (
-      <button
+      <Button type="button" variant="ghost" size="none"
         className="flex-1 flex items-center justify-center relative overflow-hidden rounded"
         onClick={() => window.open(getWatchUrl(localConfig.videoId!), '_blank', 'noopener,noreferrer')}
         title={videoTitle || 'Play on YouTube'}
@@ -186,7 +186,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
         <div className={`relative z-10 p-1 ${PLAY_BUTTON_CHROME_CLASS}`}>
           <Play className="h-3 w-3 text-white fill-white" />
         </div>
-      </button>
+      </Button>
     );
   };
 
@@ -202,7 +202,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
     }
     return (
       <div className="flex-1 flex items-center gap-2 overflow-hidden px-1">
-        <button
+        <Button type="button" variant="ghost" size="none"
           onClick={() => window.open(getWatchUrl(localConfig.videoId!), '_blank', 'noopener,noreferrer')}
           className="shrink-0 relative rounded overflow-hidden"
           style={{ width: Math.max(width * 20, 48), height: '100%' }}
@@ -217,7 +217,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
               <Play className="h-3 w-3 text-white fill-white" />
             </div>
           </div>
-        </button>
+        </Button>
         <div className="min-w-0 flex-1">
           <p className="truncate text-xs font-medium">{videoTitle || localConfig.title || 'YouTube Video'}</p>
         </div>
@@ -256,7 +256,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
 
     return (
       <div className="flex-1 flex flex-col overflow-hidden">
-        <button
+        <Button type="button" variant="ghost" size="none"
           className="flex-1 relative overflow-hidden rounded-lg cursor-pointer"
           onClick={() => setIsPlaying(true)}
         >
@@ -270,7 +270,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
               <Play className="h-5 w-5 text-white fill-white" />
             </div>
           </div>
-        </button>
+        </Button>
         <p className="mt-1 text-[10px] truncate text-muted-foreground">
           {videoTitle || localConfig.title || 'Click to play'}
         </p>
@@ -305,7 +305,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
 
     return (
       <div className="flex-1 flex flex-col overflow-hidden">
-        <button
+        <Button type="button" variant="ghost" size="none"
           className="flex-1 relative overflow-hidden rounded-lg cursor-pointer"
           onClick={() => setIsPlaying(true)}
         >
@@ -319,7 +319,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
               <Play className="h-6 w-6 text-white fill-white" />
             </div>
           </div>
-        </button>
+        </Button>
         <div className="mt-1.5 min-w-0">
           <p className="text-sm font-medium truncate">{videoTitle || localConfig.title || 'YouTube Video'}</p>
           <Button

--- a/src/components/widgets/common/WidgetHeader.tsx
+++ b/src/components/widgets/common/WidgetHeader.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react';
 import { Settings } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 interface WidgetHeaderProps {
   title?: string;
@@ -38,17 +39,19 @@ const WidgetHeader = ({
         {children}
       </div>
       {onSettingsClick && (
-        <button 
+        <Button
           type="button"
+          variant="ghost"
+          size="icon"
           aria-label={title ? `Open ${title} settings` : 'Open widget settings'}
-          className={`settings-button hover:bg-gray-100 dark:hover:bg-slate-700 rounded-full ${compact ? 'p-0.5' : 'p-0.5 md:p-1'}`}
+          className={`settings-button rounded-full ${compact ? 'size-6 p-0.5' : 'size-7 p-0.5 md:size-8 md:p-1'}`}
           onClick={(e: React.MouseEvent) => {
             e.stopPropagation();
             onSettingsClick();
           }}
         >
           <Settings size={compact ? 12 : 14} className="text-gray-500 dark:text-slate-400" />
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/components/widgets/common/WidgetSelector.tsx
+++ b/src/components/widgets/common/WidgetSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Calendar, Cloud, Clock, Link, StickyNote, CheckSquare, Timer, DollarSign, BookOpen, Video, Rss, Github, Plane, Globe } from 'lucide-react';
 import { WidgetConfig } from '@/types';
+import { Button } from '@/components/ui/button';
 
 interface WidgetSelectorProps {
   isOpen: boolean;
@@ -64,13 +65,16 @@ const WidgetSelector = ({
       <div className="bg-white dark:bg-black rounded-xl shadow-2xl dark:shadow-xl dark:shadow-black/40 w-full max-w-4xl max-h-[90vh] sm:max-h-[85vh] overflow-hidden flex flex-col border border-gray-200 dark:border-[#1c1c1e]" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
         <div className="flex justify-between items-center p-4 sm:p-5 md:p-6 border-b border-gray-200 dark:border-[#1c1c1e]">
           <h3 className="text-lg sm:text-xl font-bold text-gray-800 dark:text-white">Add Widget</h3>
-          <button 
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
             onClick={onClose} 
-            className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-[#1c1c1e] transition-colors duration-200"
+            className="rounded-full transition-colors duration-200"
             aria-label="Close widget selector"
           >
             <X size={20} className="dark:text-white" />
-          </button>
+          </Button>
         </div>
         
         <div className="relative p-4 sm:p-5 md:p-6 border-b border-gray-200 dark:border-[#1c1c1e]">
@@ -91,9 +95,11 @@ const WidgetSelector = ({
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
               {filteredWidgets.length > 0 ? (
                 filteredWidgets.map(widget => (
-                  <button
+                  <Button
                     key={widget.type}
-                    className="flex items-center gap-3 p-4 border border-gray-100 dark:border-[#2c2c2e] rounded-lg bg-white dark:bg-[#1c1c1e] transition-all duration-200 cursor-pointer hover:bg-blue-50 dark:hover:bg-[#2c2c2e] hover:border-blue-200 dark:hover:border-[#3c3c3e] hover:shadow-md dark:hover:shadow-lg dark:hover:shadow-black/20 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:focus:ring-blue-400/30"
+                    type="button"
+                    variant="ghost"
+                    className="h-auto justify-start gap-3 border border-gray-100 bg-white p-4 text-left transition-all duration-200 hover:scale-[1.02] hover:bg-blue-50 hover:border-blue-200 hover:shadow-md dark:border-[#2c2c2e] dark:bg-[#1c1c1e] dark:hover:border-[#3c3c3e] dark:hover:bg-[#2c2c2e] dark:hover:shadow-black/20 dark:hover:shadow-lg"
                     onClick={() => onAddWidget(widget.type)}
                     aria-label={`Add ${widget.name} widget`}
                   >
@@ -124,7 +130,7 @@ const WidgetSelector = ({
                         <div className="text-xs text-gray-500 dark:text-[#8e8e93] mt-0.5">{widget.description}</div>
                       )}
                     </div>
-                  </button>
+                  </Button>
                 ))
               ) : (
                 <div className="col-span-full text-center py-8 text-gray-500 dark:text-[#8e8e93] text-sm">No widgets found matching "{searchQuery}"</div>
@@ -138,9 +144,11 @@ const WidgetSelector = ({
                 <h4 className="text-base font-semibold text-gray-700 dark:text-[#f5f5f7] mb-2">{category}</h4>
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
                   {widgets.map(widget => (
-                    <button
+                    <Button
                       key={widget.type}
-                      className="flex items-center gap-3 p-4 border border-gray-100 dark:border-[#2c2c2e] rounded-lg bg-white dark:bg-[#1c1c1e] transition-all duration-200 cursor-pointer hover:bg-blue-50 dark:hover:bg-[#2c2c2e] hover:border-blue-200 dark:hover:border-[#3c3c3e] hover:shadow-md dark:hover:shadow-lg dark:hover:shadow-black/20 hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500/30 dark:focus:ring-blue-400/30"
+                      type="button"
+                      variant="ghost"
+                      className="h-auto justify-start gap-3 border border-gray-100 bg-white p-4 text-left transition-all duration-200 hover:scale-[1.02] hover:bg-blue-50 hover:border-blue-200 hover:shadow-md dark:border-[#2c2c2e] dark:bg-[#1c1c1e] dark:hover:border-[#3c3c3e] dark:hover:bg-[#2c2c2e] dark:hover:shadow-black/20 dark:hover:shadow-lg"
                       onClick={() => onAddWidget(widget.type)}
                       aria-label={`Add ${widget.name} widget`}
                     >
@@ -171,7 +179,7 @@ const WidgetSelector = ({
                           <div className="text-xs text-gray-500 dark:text-[#8e8e93] mt-0.5">{widget.description}</div>
                         )}
                       </div>
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </div>

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -559,21 +559,21 @@ test('keeps app-mode text button controls from triggering widget press or drag v
   const todoWidget = page.locator('.react-grid-item[data-widget-id="todo-app"]');
   const quickLinksWidget = page.locator('.react-grid-item[data-widget-id="quick-links-app"]');
 
-  const weekButton = calendarWidget.getByRole('button', { name: 'Week' });
-  await expect(weekButton).toBeVisible();
+  const weekTab = calendarWidget.getByRole('tab', { name: 'Week' });
+  await expect(weekTab).toBeVisible();
 
   await dragFromTextNodeWithoutStartingWidgetInteraction(
     page,
     calendarWidget,
-    weekButton,
+    weekTab,
     0,
     'calendar-app'
   );
 
-  const weekPoint = await readFirstTextNodeCenter(weekButton);
+  const weekPoint = await readFirstTextNodeCenter(weekTab);
   await page.mouse.click(weekPoint.x, weekPoint.y);
   await assertWidgetInteractionInactive(calendarWidget);
-  await expect.poll(async () => weekButton.getAttribute('class')).toContain('bg-background');
+  await expect.poll(async () => weekTab.getAttribute('class')).toContain('bg-background');
   await expect.poll(async () => readStoredLayoutX(page, 'calendar-app')).toBe(0);
 
   const todoComposer = todoWidget.getByRole('textbox', { name: 'New task' });

--- a/tests/e2e/widget-control-migration.spec.ts
+++ b/tests/e2e/widget-control-migration.spec.ts
@@ -1,0 +1,283 @@
+import { mkdir } from 'node:fs/promises';
+
+import { expect, test, type Page } from '@playwright/test';
+
+import { seedDashboard } from './helpers/dashboardSeed';
+
+test.describe.configure({ mode: 'serial' });
+test.setTimeout(90_000);
+
+const LIGHT_DASHBOARD = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-light.png';
+const DARK_DASHBOARD = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-dark.png';
+const LIGHT_RSS = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-rss-light.png';
+const DARK_WEATHER = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-weather-dark.png';
+const DARK_IFRAME = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-iframe-dark.png';
+const DARK_QRCODE = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-qrcode-dark.png';
+
+const RSS_FEEDS = {
+  'https://feeds.example/engineering.xml': `<?xml version="1.0"?><rss version="2.0"><channel><title>Engineering</title><item><title>Replace controls with primitives</title><link>https://example.com/eng-1</link><description>Button and textarea migration complete.</description><pubDate>Fri, 14 Mar 2026 12:00:00 GMT</pubDate><author>Alex</author></item><item><title>Validate tabs and sliders</title><link>https://example.com/eng-2</link><description>Calendar and iframe widgets verified.</description><pubDate>Thu, 13 Mar 2026 12:00:00 GMT</pubDate><author>Sam</author></item></channel></rss>`,
+  'https://feeds.example/design.xml': `<?xml version="1.0"?><rss version="2.0"><channel><title>Design</title><item><title>Dark mode audit</title><link>https://example.com/des-1</link><description>Dropdowns and tabs align with the system palette.</description><pubDate>Fri, 14 Mar 2026 11:30:00 GMT</pubDate><author>Jamie</author></item></channel></rss>`,
+} as const;
+
+const WEATHER_PAYLOAD = {
+  current: {
+    temperature_2m: 21,
+    relative_humidity_2m: 54,
+    apparent_temperature: 22,
+    weather_code: 1,
+    wind_speed_10m: 9,
+    wind_direction_10m: 230,
+  },
+  daily: {
+    time: ['2026-03-14', '2026-03-15', '2026-03-16', '2026-03-17', '2026-03-18'],
+    weather_code: [1, 2, 3, 61, 0],
+    temperature_2m_max: [24, 23, 22, 19, 25],
+    temperature_2m_min: [14, 13, 12, 11, 15],
+    sunrise: ['2026-03-14T07:26:00-03:00', '2026-03-15T07:27:00-03:00', '2026-03-16T07:28:00-03:00', '2026-03-17T07:29:00-03:00', '2026-03-18T07:30:00-03:00'],
+    sunset: ['2026-03-14T19:46:00-03:00', '2026-03-15T19:44:00-03:00', '2026-03-16T19:43:00-03:00', '2026-03-17T19:41:00-03:00', '2026-03-18T19:40:00-03:00'],
+  },
+} as const;
+
+const configureExternalRoutes = async (page: Page) => {
+  await page.route('https://www.googleapis.com/calendar/v3/users/me/calendarList', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: 'primary',
+            summary: 'Primary',
+            backgroundColor: '#4285F4',
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('https://www.googleapis.com/calendar/v3/calendars/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: [
+          {
+            id: 'evt-1',
+            summary: 'Design review',
+            start: { dateTime: '2026-03-14T15:00:00.000Z' },
+            end: { dateTime: '2026-03-14T16:00:00.000Z' },
+          },
+          {
+            id: 'evt-2',
+            summary: 'Release checklist',
+            start: { dateTime: '2026-03-15T18:00:00.000Z' },
+            end: { dateTime: '2026-03-15T19:00:00.000Z' },
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('**/api/rss?*', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const url = requestUrl.searchParams.get('url') || 'https://feeds.example/engineering.xml';
+    const body = RSS_FEEDS[url as keyof typeof RSS_FEEDS] ?? RSS_FEEDS['https://feeds.example/engineering.xml'];
+    await route.fulfill({ status: 200, contentType: 'application/rss+xml', body });
+  });
+
+  await page.route('https://geocoding-api.open-meteo.com/v1/search?*', async (route) => {
+    const requestUrl = new URL(route.request().url());
+    const query = (requestUrl.searchParams.get('name') || '').toLowerCase();
+    const results = query.startsWith('san')
+      ? {
+          results: [
+            { id: 2, name: 'San Francisco', country: 'United States', admin1: 'California', latitude: 37.77, longitude: -122.42 },
+            { id: 3, name: 'San Diego', country: 'United States', admin1: 'California', latitude: 32.72, longitude: -117.16 },
+            { id: 4, name: 'San Jose', country: 'United States', admin1: 'California', latitude: 37.33, longitude: -121.89 },
+          ],
+        }
+      : {
+          results: [
+            { id: 1, name: 'Santiago', country: 'Chile', admin1: 'Santiago Metropolitan', latitude: -33.45, longitude: -70.66 },
+          ],
+        };
+
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(results) });
+  });
+
+  await page.route('https://api.open-meteo.com/v1/forecast?*', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(WEATHER_PAYLOAD) });
+  });
+};
+
+const setTheme = async (page: Page, theme: 'light' | 'dark') => {
+  const appRoot = page.locator('[data-theme]').first();
+  const currentTheme = await appRoot.getAttribute('data-theme');
+
+  if (currentTheme !== theme) {
+    await page.getByRole('button', { name: 'Toggle theme' }).click();
+  }
+
+  await expect(appRoot).toHaveAttribute('data-theme', theme);
+  await expect(page.locator('html')).toHaveClass(theme === 'dark' ? /dark/ : /^(?!.*dark).*$/);
+};
+
+test('captures representative migrated controls in light and dark themes', async ({ page, baseURL }) => {
+  await mkdir('/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright', { recursive: true });
+  await page.setViewportSize({ width: 1600, height: 2200 });
+  await configureExternalRoutes(page);
+
+  await seedDashboard(page, {
+    widgets: [
+      {
+        id: 'calendar-app',
+        type: 'calendar',
+        config: {
+          title: 'Calendar',
+          googleCalendarConnected: true,
+          viewMode: 'month',
+          calendars: [
+            {
+              id: 'primary',
+              name: 'Primary',
+              color: '#4285F4',
+              selected: true,
+            },
+          ],
+        },
+      },
+      {
+        id: 'rss-app',
+        type: 'rss',
+        config: {
+          title: 'RSS Reader',
+          feeds: [
+            { title: 'Engineering', url: 'https://feeds.example/engineering.xml', enabled: true },
+            { title: 'Design', url: 'https://feeds.example/design.xml', enabled: true },
+          ],
+          maxItems: 5,
+          showImages: false,
+          showDate: true,
+          showAuthor: true,
+          showDescription: true,
+          displayMode: 'list',
+          openInNewTab: true,
+        },
+      },
+      { id: 'weather-app', type: 'weather', config: { title: 'Weather', location: 'Santiago', units: 'metric' } },
+      { id: 'iframe-1', type: 'iframe', config: { title: 'Embed', url: `${baseURL}/index.html`, scale: 1, alignment: 'top' } },
+      { id: 'qrcode-1', type: 'qrcode', config: { title: 'QR Code', content: 'https://boxento.test', errorLevel: 'M', history: [{ id: 'qr-1', content: 'https://boxento.test', label: 'Boxento' }] } },
+      { id: 'notes-1', type: 'notes', config: { title: 'Notes', content: 'Replace native controls\nUse Tabs, DropdownMenu, Slider, and Textarea\nVerify light and dark mode.' } },
+      {
+        id: 'todo-app',
+        type: 'todo',
+        config: {
+          title: 'Operations Todo',
+          items: [
+            { id: 'todo-1', text: 'Replace native buttons', completed: false, createdAt: '2026-03-12T00:00:00.000Z', sortOrder: 0 },
+            { id: 'todo-2', text: 'Validate widget settings', completed: false, createdAt: '2026-03-12T00:01:00.000Z', sortOrder: 1 },
+            { id: 'todo-3', text: 'Record blocker state', completed: true, createdAt: '2026-03-12T00:02:00.000Z', sortOrder: 2 },
+          ],
+          showCompletedItems: true,
+          sortOrder: 'manual',
+        },
+      },
+      {
+        id: 'services-1',
+        type: 'services',
+        config: {
+          title: 'Services',
+          services: [
+            { id: 'boxento', name: 'Boxento', url: 'https://boxento.test', icon: 'LayoutGrid', description: 'Dashboard', category: 'Utilities' },
+            { id: 'paisa', name: 'Paisa', url: 'https://paisa.test', icon: 'PiggyBank', description: 'Personal Finance', category: 'Finance' },
+            { id: 'jellyfin', name: 'Jellyfin', url: 'https://jellyfin.test', icon: 'Play', description: 'Media Server', category: 'Media' },
+            { id: 'open-webui', name: 'Open WebUI', url: 'https://open-webui.test', icon: 'Bot', description: 'Local AI Chat', category: 'AI' },
+          ],
+          showStatus: false,
+          checkInterval: 60,
+        },
+      },
+    ],
+    layouts: {
+      lg: [
+        { i: 'calendar-app', x: 0, y: 0, w: 6, h: 6, minW: 2, minH: 2 },
+        { i: 'rss-app', x: 6, y: 0, w: 6, h: 6, minW: 2, minH: 2 },
+        { i: 'weather-app', x: 0, y: 6, w: 4, h: 4, minW: 2, minH: 2 },
+        { i: 'iframe-1', x: 4, y: 6, w: 4, h: 4, minW: 2, minH: 2 },
+        { i: 'qrcode-1', x: 8, y: 6, w: 4, h: 4, minW: 2, minH: 2 },
+        { i: 'notes-1', x: 0, y: 10, w: 4, h: 4, minW: 2, minH: 2 },
+        { i: 'todo-app', x: 4, y: 10, w: 4, h: 4, minW: 2, minH: 2 },
+        { i: 'services-1', x: 8, y: 10, w: 4, h: 4, minW: 2, minH: 2 },
+      ],
+    },
+  });
+  await page.evaluate(() => {
+    localStorage.setItem('googleAccessToken-calendar-app', 'test-access-token');
+    localStorage.setItem('googleRefreshToken-calendar-app', 'test-refresh-token');
+    localStorage.setItem('googleTokenExpiry-calendar-app', String(Date.now() + 60 * 60 * 1000));
+  });
+  await page.reload();
+
+  const calendarWidget = page.locator('.react-grid-item[data-widget-id="calendar-app"]');
+  const rssWidget = page.locator('.react-grid-item[data-widget-id="rss-app"]');
+  const weatherWidget = page.locator('.react-grid-item[data-widget-id="weather-app"]');
+  const iframeWidget = page.locator('.react-grid-item[data-widget-id="iframe-1"]');
+  const qrWidget = page.locator('.react-grid-item[data-widget-id="qrcode-1"]');
+  const notesWidget = page.locator('.react-grid-item[data-widget-id="notes-1"]');
+
+  await expect(calendarWidget.getByRole('tab', { name: 'Week' })).toBeVisible();
+  await calendarWidget.getByRole('tab', { name: 'Week' }).click();
+  await expect(calendarWidget.getByRole('tab', { name: 'Week' })).toHaveAttribute('aria-selected', 'true');
+
+  await expect(notesWidget.getByRole('textbox', { name: 'Notes content' })).toBeVisible();
+
+  await page.screenshot({ path: LIGHT_DASHBOARD, fullPage: true });
+
+  const feedFilter = rssWidget.getByRole('button', { name: 'All Feeds' });
+  await feedFilter.click();
+  await expect(page.getByRole('menuitemradio', { name: 'Engineering' })).toBeVisible();
+  await expect(page.getByRole('menuitemradio', { name: 'Design' })).toBeVisible();
+  await page.screenshot({ path: LIGHT_RSS, fullPage: true });
+  await page.keyboard.press('Escape');
+
+  await setTheme(page, 'dark');
+
+  const weatherSettings = weatherWidget.getByRole('button', { name: 'Open widget settings' });
+  await weatherSettings.click();
+  const weatherDialog = page.getByRole('dialog').filter({ hasText: 'Weather Settings' });
+  await expect(weatherDialog).toBeVisible();
+  await weatherDialog.getByLabel('Location').fill('San');
+  await expect(page.getByRole('button', { name: /San Francisco/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /San Diego/i })).toBeVisible();
+  await page.screenshot({ path: DARK_WEATHER, fullPage: true });
+  await page.getByRole('button', { name: /San Francisco/i }).click();
+  await expect(page.getByRole('button', { name: /San Diego/i })).toBeHidden();
+  await weatherDialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(weatherDialog).toBeHidden();
+
+  await iframeWidget.scrollIntoViewIfNeeded();
+  const iframeSettings = iframeWidget.locator('.settings-button').first();
+  await iframeSettings.click();
+  const iframeDialog = page.getByRole('dialog').filter({ hasText: 'Embed Settings' });
+  await expect(iframeDialog).toBeVisible();
+  const iframeSlider = iframeDialog.getByRole('slider');
+  await expect(iframeSlider).toBeVisible();
+  const initialScale = Number((await iframeSlider.getAttribute('aria-valuenow')) || '0');
+  await iframeSlider.press('ArrowRight');
+  await expect.poll(async () => Number((await iframeSlider.getAttribute('aria-valuenow')) || '0')).toBeGreaterThan(initialScale);
+  await page.screenshot({ path: DARK_IFRAME, fullPage: true });
+  await iframeDialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(iframeDialog).toBeHidden();
+
+  await qrWidget.scrollIntoViewIfNeeded();
+  const qrSettings = qrWidget.locator('.settings-button').first();
+  await qrSettings.click();
+  const qrDialog = page.getByRole('dialog').filter({ hasText: 'QR Code Settings' });
+  await expect(qrDialog).toBeVisible();
+  await expect(qrDialog.getByLabel('Content (URL or text)')).toBeVisible();
+  await page.screenshot({ path: DARK_QRCODE, fullPage: true });
+  await qrDialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(qrDialog).toBeHidden();
+
+  await page.screenshot({ path: DARK_DASHBOARD, fullPage: true });
+});

--- a/tests/e2e/widget-control-migration.spec.ts
+++ b/tests/e2e/widget-control-migration.spec.ts
@@ -1,4 +1,5 @@
 import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
 
 import { expect, test, type Page } from '@playwright/test';
 
@@ -7,12 +8,13 @@ import { seedDashboard } from './helpers/dashboardSeed';
 test.describe.configure({ mode: 'serial' });
 test.setTimeout(90_000);
 
-const LIGHT_DASHBOARD = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-light.png';
-const DARK_DASHBOARD = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-dark.png';
-const LIGHT_RSS = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-rss-light.png';
-const DARK_WEATHER = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-weather-dark.png';
-const DARK_IFRAME = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-iframe-dark.png';
-const DARK_QRCODE = '/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright/widget-control-migration-qrcode-dark.png';
+const OUTPUT_DIR = join('output', 'playwright');
+const LIGHT_DASHBOARD = join(OUTPUT_DIR, 'widget-control-migration-light.png');
+const DARK_DASHBOARD = join(OUTPUT_DIR, 'widget-control-migration-dark.png');
+const LIGHT_RSS = join(OUTPUT_DIR, 'widget-control-migration-rss-light.png');
+const DARK_WEATHER = join(OUTPUT_DIR, 'widget-control-migration-weather-dark.png');
+const DARK_IFRAME = join(OUTPUT_DIR, 'widget-control-migration-iframe-dark.png');
+const DARK_QRCODE = join(OUTPUT_DIR, 'widget-control-migration-qrcode-dark.png');
 
 const RSS_FEEDS = {
   'https://feeds.example/engineering.xml': `<?xml version="1.0"?><rss version="2.0"><channel><title>Engineering</title><item><title>Replace controls with primitives</title><link>https://example.com/eng-1</link><description>Button and textarea migration complete.</description><pubDate>Fri, 14 Mar 2026 12:00:00 GMT</pubDate><author>Alex</author></item><item><title>Validate tabs and sliders</title><link>https://example.com/eng-2</link><description>Calendar and iframe widgets verified.</description><pubDate>Thu, 13 Mar 2026 12:00:00 GMT</pubDate><author>Sam</author></item></channel></rss>`,
@@ -123,7 +125,7 @@ const setTheme = async (page: Page, theme: 'light' | 'dark') => {
 };
 
 test('captures representative migrated controls in light and dark themes', async ({ page, baseURL }) => {
-  await mkdir('/Users/sushaantu/code/symphony-workspaces/boxento/SUS-32/output/playwright', { recursive: true });
+  await mkdir(OUTPUT_DIR, { recursive: true });
   await page.setViewportSize({ width: 1600, height: 2200 });
   await configureExternalRoutes(page);
 


### PR DESCRIPTION
## Summary
- replace remaining native widget controls with shadcn/ui primitives
- add shared textarea and migrate remaining textarea/button/dropdown/tab/slider sites
- add focused widget-control migration E2E coverage and screenshot-backed light/dark review

## Validation
- bun run lint
- bun run test
- bun run build:types
- bun run test:e2e