### PR TITLE
SUS-24: document sandbox Playwright constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ firebase-debug.*.log*
 .rts2_cache_umd/
 .cache
 .rollup.cache
+/.tmp
+/.bun-home
 
 # Package managers
 .yarn/*

--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ Anyone can create widgets - no matter your experience level:
 3. Test locally with `bun run dev`
 4. Submit a PR
 
+### Browser E2E In Sandboxed Sessions
+Codex/macOS sandbox sessions on this machine can block localhost binding, browser launch, and even loopback browser websocket connections for Playwright. See the current limitations and required environment changes in [Sandbox E2E Guide](/docs/E2E_SANDBOX.md).
+
 ### Reporting Issues
 Found a bug or have a feature request? Open an issue on our [GitHub repository](https://github.com/sushaantu/boxento/issues).
 

--- a/docs/E2E_SANDBOX.md
+++ b/docs/E2E_SANDBOX.md
@@ -1,0 +1,77 @@
+# Playwright E2E In Sandboxed Codex Sessions
+
+## Problem Summary
+
+On this machine's current macOS Codex sandbox, Boxento's browser E2E suite hits two independent platform restrictions before any app assertion runs:
+
+- Playwright cannot start its own Vite server because binding `127.0.0.1` fails with `listen EPERM`.
+- Browser launch aborts before a context is created. The direct Chrome for Testing probe exits with `SIGABRT`, and Playwright then reports `browserType.launch: Target page, context or browser has been closed`.
+
+That means a self-contained `bun run test:e2e` invocation inside the sandbox is not a viable path today, even when the Boxento implementation and static build are correct.
+
+## Current Result On This Machine
+
+There is no fully sandbox-compatible Playwright execution path in the current Codex/macOS shell profile on this machine.
+
+Validated constraints:
+
+- local web-server bind fails with `listen EPERM`
+- local browser launch fails with `SIGABRT`
+- loopback websocket/TCP connect also fails with `EPERM`, so `browserType.connect()` to a same-machine browser server is blocked too
+
+That means the practical requirement today is an environment change, not another Playwright flag.
+
+## What Still Helps
+
+The repo now supports remote-browser configuration for future or less-restricted environments:
+
+- `scripts/start-playwright-server.mjs`
+- `PLAYWRIGHT_CONNECT_WS_ENDPOINT`
+- `PLAYWRIGHT_CONNECT_WS_ENDPOINT_FILE`
+- `PLAYWRIGHT_CONNECT_EXPOSE_NETWORK`
+
+Those hooks are useful if a future Codex session can open outbound TCP connections to the browser endpoint. In the current shell profile, even a fake `ws://127.0.0.1:<port>` endpoint fails immediately with `connect EPERM`.
+
+## Required Environment Changes
+
+To run Boxento browser E2E reliably in unattended Codex sessions on this machine, the environment must allow all of the following:
+
+- launching a browser process from the session
+- binding a local dev server or otherwise serving the app to the browser
+- opening outbound TCP connections to the Playwright browser endpoint
+
+Without those capabilities, the browser suite has to run outside the sandbox.
+
+## Practical Workflow Today
+
+Run the browser E2E command from a normal host shell, CI runner, or another execution environment that permits browser launch plus socket I/O.
+
+Example host-shell flow:
+
+```bash
+bun install
+bun run build
+bun run test:e2e -- tests/e2e/dashboard-switching.spec.ts --workers=1
+```
+
+## Fail-Fast Behavior
+
+`scripts/run-playwright.mjs` now performs a lightweight preflight before invoking Playwright:
+
+- loopback bind check when Playwright would otherwise start its own web server
+- websocket endpoint reachability check when `PLAYWRIGHT_CONNECT_WS_ENDPOINT` or `PLAYWRIGHT_CONNECT_WS_ENDPOINT_FILE` is configured
+- local browser launch check when no remote websocket endpoint is configured
+
+If any prerequisite is unavailable, the runner exits immediately with guidance that points back to this document instead of waiting for the opaque `SIGABRT`, `Target page, context or browser has been closed`, or late websocket connection failure paths.
+
+Set `PLAYWRIGHT_SKIP_ENV_CHECK=1` to bypass those checks when you need the old behavior.
+
+## Unsupported Path In The Current Sandbox
+
+The following combinations remain unsupported in the current Codex/macOS sandbox on this machine:
+
+- Playwright launches a browser locally inside the sandbox.
+- Playwright launches its own localhost web server inside the sandbox.
+- Playwright connects to a browser websocket endpoint bound on loopback from inside the sandbox.
+
+Until the sandbox profile changes to allow browser launch plus the necessary socket access, Boxento E2E validation has to move outside this sandbox.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "bunx vitest run",
     "test:watch": "bunx vitest",
     "test:e2e": "node scripts/run-playwright.mjs",
+    "test:e2e:server": "node scripts/start-playwright-server.mjs",
     "test:e2e:reuse": "PLAYWRIGHT_USE_EXISTING_SERVER=1 node scripts/run-playwright.mjs",
     "preview": "bunx --bun vite preview",
     "deploy": "bun run build && firebase deploy --only hosting"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,9 @@ const defaultPlaywrightPort = 45000 + ((workspacePortSeed + process.pid) % 10000
 const playwrightPort = Number(process.env.PLAYWRIGHT_PORT || defaultPlaywrightPort);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${playwrightPort}`;
 const shouldStartWebServer = !reuseExistingServer && !baseURL.startsWith('file://');
+const playwrightConnectWsEndpoint = process.env.PLAYWRIGHT_CONNECT_WS_ENDPOINT;
+const playwrightConnectExposeNetwork = process.env.PLAYWRIGHT_CONNECT_EXPOSE_NETWORK;
+const playwrightConnectTimeout = Number(process.env.PLAYWRIGHT_CONNECT_TIMEOUT_MS || 0);
 const playwrightChannel = process.env.PLAYWRIGHT_CHANNEL;
 const playwrightExecutablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
 const playwrightExtraArgs = (process.env.PLAYWRIGHT_EXTRA_ARGS || '')
@@ -25,19 +28,29 @@ export default defineConfig({
   timeout: 30_000,
   use: {
     baseURL,
-    ...(playwrightChannel ? { channel: playwrightChannel } : {}),
-    ...((playwrightExecutablePath || playwrightExtraArgs.length)
+    ...(playwrightConnectWsEndpoint
       ? {
-          launchOptions: {
-            ...(playwrightExecutablePath ? { executablePath: playwrightExecutablePath } : {}),
-            ...(playwrightExtraArgs.length ? { args: playwrightExtraArgs } : {}),
+          connectOptions: {
+            wsEndpoint: playwrightConnectWsEndpoint,
+            ...(playwrightConnectExposeNetwork ? { exposeNetwork: playwrightConnectExposeNetwork } : {}),
+            ...(playwrightConnectTimeout > 0 ? { timeout: playwrightConnectTimeout } : {}),
           },
         }
-      : {}),
+      : {
+          ...(playwrightChannel ? { channel: playwrightChannel } : {}),
+          ...((playwrightExecutablePath || playwrightExtraArgs.length)
+            ? {
+                launchOptions: {
+                  ...(playwrightExecutablePath ? { executablePath: playwrightExecutablePath } : {}),
+                  ...(playwrightExtraArgs.length ? { args: playwrightExtraArgs } : {}),
+                },
+              }
+            : {}),
+        }),
     trace: 'on-first-retry',
   },
   webServer: shouldStartWebServer ? {
-    command: `bunx --bun vite --host 127.0.0.1 --port ${playwrightPort} --strictPort`,
+    command: `npx --no-install vite --host 127.0.0.1 --port ${playwrightPort} --strictPort`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/scripts/run-playwright.mjs
+++ b/scripts/run-playwright.mjs
@@ -1,4 +1,7 @@
 import { execFileSync, spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createConnection, createServer } from 'node:net';
+import { resolve } from 'node:path';
 
 const workspaceSeed = Array.from(process.cwd()).reduce(
   (hash, character) => (hash * 31 + character.charCodeAt(0)) % 10000,
@@ -25,6 +28,12 @@ try {
 
 const preferredPort = 45000 + workspaceSeed;
 const fallbackRange = 400;
+const reuseExistingServer = process.env.PLAYWRIGHT_USE_EXISTING_SERVER === '1';
+const skipEnvironmentCheck = process.env.PLAYWRIGHT_SKIP_ENV_CHECK === '1';
+const playwrightExtraArgs = (process.env.PLAYWRIGHT_EXTRA_ARGS || '')
+  .split(',')
+  .map((arg) => arg.trim())
+  .filter(Boolean);
 
 const selectPort = () => {
   const overriddenPort = Number(process.env.PLAYWRIGHT_PORT);
@@ -43,25 +52,254 @@ const selectPort = () => {
   return preferredPort;
 };
 
-const playwrightPort = selectPort();
-const child = spawn(
-  'bunx',
-  ['playwright', 'test', ...process.argv.slice(2)],
-  {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      PLAYWRIGHT_PORT: String(playwrightPort),
-    },
-    shell: process.platform === 'win32',
+const readConnectEndpoint = () => {
+  if (process.env.PLAYWRIGHT_CONNECT_WS_ENDPOINT) {
+    return process.env.PLAYWRIGHT_CONNECT_WS_ENDPOINT;
   }
+
+  const endpointFile = process.env.PLAYWRIGHT_CONNECT_WS_ENDPOINT_FILE;
+
+  if (!endpointFile) {
+    return undefined;
+  }
+
+  const resolvedEndpointFile = resolve(endpointFile);
+
+  try {
+    const endpoint = readFileSync(resolvedEndpointFile, 'utf8').trim();
+
+    if (!endpoint) {
+      throw new Error('is empty');
+    }
+
+    return endpoint;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to read PLAYWRIGHT_CONNECT_WS_ENDPOINT_FILE at ${resolvedEndpointFile}: ${reason}.`
+    );
+  }
+};
+
+const parseConnectEndpoint = (connectEndpoint) => {
+  try {
+    const url = new URL(connectEndpoint);
+
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      return null;
+    }
+
+    return {
+      endpoint: connectEndpoint,
+      host: url.hostname,
+      port: Number(url.port || (url.protocol === 'wss:' ? 443 : 80)),
+    };
+  } catch {
+    return null;
+  }
+};
+
+const listenOnLoopback = () => new Promise((resolveListen, rejectListen) => {
+  const server = createServer();
+
+  server.once('error', rejectListen);
+  server.listen(0, '127.0.0.1', () => {
+    server.close((closeError) => {
+      if (closeError) {
+        rejectListen(closeError);
+        return;
+      }
+
+      resolveListen();
+    });
+  });
+});
+
+const connectToTcpEndpoint = ({ host, port }) => new Promise((resolveConnect, rejectConnect) => {
+  const socket = createConnection({ host, port });
+
+  const settle = (error) => {
+    socket.removeAllListeners();
+    socket.destroy();
+
+    if (error) {
+      rejectConnect(error);
+      return;
+    }
+
+    resolveConnect();
+  };
+
+  socket.setTimeout(3_000, () => {
+    const timeoutError = new Error(`Timed out connecting to ${host}:${port}.`);
+    timeoutError.code = 'ETIMEDOUT';
+    settle(timeoutError);
+  });
+  socket.once('connect', () => {
+    settle();
+  });
+  socket.once('error', (error) => {
+    settle(error);
+  });
+});
+
+const loadPlaywright = async () => {
+  try {
+    return await import('@playwright/test');
+  } catch (error) {
+    if (
+      error instanceof Error
+      && ('code' in error ? error.code === 'ERR_MODULE_NOT_FOUND' : false)
+    ) {
+      return null;
+    }
+
+    throw error;
+  }
+};
+
+const formatPreflightFailure = (title, detail, nextSteps) => [
+  `${title}`,
+  '',
+  detail,
+  '',
+  'Next steps:',
+  ...nextSteps.map((step) => `- ${step}`),
+].join('\n');
+
+const isLoopbackHost = (host) => (
+  host === '127.0.0.1'
+  || host === 'localhost'
+  || host === '::1'
 );
 
-child.on('exit', (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
+const probeLocalBrowserLaunch = async (playwright) => {
+  const browserType = playwright.chromium;
+  const headedMode = process.argv.includes('--headed');
+  const browser = await browserType.launch({
+    headless: !headedMode && process.env.PLAYWRIGHT_HEADLESS !== '0',
+    ...(process.env.PLAYWRIGHT_CHANNEL ? { channel: process.env.PLAYWRIGHT_CHANNEL } : {}),
+    ...(process.env.PLAYWRIGHT_EXECUTABLE_PATH ? { executablePath: process.env.PLAYWRIGHT_EXECUTABLE_PATH } : {}),
+    ...(playwrightExtraArgs.length ? { args: playwrightExtraArgs } : {}),
+  });
+
+  await browser.close();
+};
+
+const assertPlaywrightEnvironment = async (playwrightBaseURL, connectEndpoint) => {
+  if (skipEnvironmentCheck) {
     return;
   }
 
-  process.exit(code ?? 1);
-});
+  const shouldStartWebServer = !reuseExistingServer && !playwrightBaseURL.startsWith('file://');
+
+  if (shouldStartWebServer) {
+    try {
+      await listenOnLoopback();
+    } catch (error) {
+      const detail = error instanceof Error
+        ? `This session cannot bind a loopback web server for Playwright (${error.message}).`
+        : `This session cannot bind a loopback web server for Playwright (${String(error)}).`;
+      throw new Error(formatPreflightFailure(
+        'Playwright E2E preflight failed.',
+        detail,
+        [
+          'Run against an existing server or static build with PLAYWRIGHT_USE_EXISTING_SERVER=1.',
+          'Use PLAYWRIGHT_BASE_URL=file:///absolute/path/to/dist/ to avoid localhost entirely.',
+          'See docs/E2E_SANDBOX.md for the current environment requirements.',
+        ]
+      ));
+    }
+  }
+
+  if (connectEndpoint) {
+    const connectTarget = parseConnectEndpoint(connectEndpoint);
+
+    if (connectTarget) {
+      try {
+        await connectToTcpEndpoint(connectTarget);
+      } catch (error) {
+        const errorCode = error instanceof Error && 'code' in error ? error.code : undefined;
+        const reason = error instanceof Error ? error.message : String(error);
+        const loopbackNote = isLoopbackHost(connectTarget.host)
+          ? ' On this machine\'s current Codex/macOS sandbox, loopback websocket connections also fail with EPERM, so a browser server bound only to localhost is not a viable workaround.'
+          : '';
+
+        throw new Error(formatPreflightFailure(
+          'Playwright E2E preflight failed.',
+          `This session cannot reach the configured Playwright browser endpoint at ${connectTarget.endpoint} (${reason}).${loopbackNote}`,
+          [
+            errorCode === 'EPERM'
+              ? 'Use a less restrictive session that allows outbound TCP connections, or run the full browser suite outside the sandbox.'
+              : 'Ensure the browser server is already listening on the configured host and port.',
+            isLoopbackHost(connectTarget.host)
+              ? 'If you keep using browserType.connect, expose the browser server on a non-loopback address that this session can reach.'
+              : 'If the endpoint host is correct but still blocked, this sandbox profile needs to allow outbound socket connections.',
+            'See docs/E2E_SANDBOX.md for the current environment requirements.',
+          ]
+        ));
+      }
+    }
+
+    return;
+  }
+
+  const playwright = await loadPlaywright();
+
+  if (!playwright) {
+    return;
+  }
+
+  try {
+    await probeLocalBrowserLaunch(playwright);
+  } catch (error) {
+    const detail = error instanceof Error
+      ? `Local browser launch failed during preflight. In this macOS Codex sandbox that usually surfaces later as SIGABRT/SIGTRAP before Playwright creates a context.\n\n${error.message}`
+      : `Local browser launch failed during preflight: ${String(error)}`;
+    throw new Error(formatPreflightFailure(
+      'Playwright E2E preflight failed.',
+      detail,
+      [
+        'Start a Playwright browser server outside the sandbox and set PLAYWRIGHT_CONNECT_WS_ENDPOINT or PLAYWRIGHT_CONNECT_WS_ENDPOINT_FILE.',
+        'Or run the full E2E command outside the sandbox.',
+        'See docs/E2E_SANDBOX.md for examples.',
+      ]
+    ));
+  }
+};
+
+const playwrightPort = selectPort();
+const playwrightBaseURL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${playwrightPort}`;
+
+try {
+  const connectEndpoint = readConnectEndpoint();
+
+  await assertPlaywrightEnvironment(playwrightBaseURL, connectEndpoint);
+
+  const child = spawn(
+    'npx',
+    ['--no-install', 'playwright', 'test', ...process.argv.slice(2)],
+    {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        PLAYWRIGHT_PORT: String(playwrightPort),
+        ...(connectEndpoint ? { PLAYWRIGHT_CONNECT_WS_ENDPOINT: connectEndpoint } : {}),
+      },
+      shell: process.platform === 'win32',
+    }
+  );
+
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 1);
+  });
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/start-playwright-server.mjs
+++ b/scripts/start-playwright-server.mjs
@@ -1,0 +1,108 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const browserName = process.env.PLAYWRIGHT_BROWSER || 'chromium';
+const playwrightChannel = process.env.PLAYWRIGHT_CHANNEL;
+const playwrightExecutablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+const playwrightServerHost = process.env.PLAYWRIGHT_SERVER_HOST || '127.0.0.1';
+const playwrightServerPort = Number(process.env.PLAYWRIGHT_SERVER_PORT || 0);
+const endpointFile = process.env.PLAYWRIGHT_WS_ENDPOINT_FILE;
+const playwrightExtraArgs = (process.env.PLAYWRIGHT_EXTRA_ARGS || '')
+  .split(',')
+  .map((arg) => arg.trim())
+  .filter(Boolean);
+
+const loadPlaywright = async () => {
+  try {
+    return await import('@playwright/test');
+  } catch (error) {
+    if (
+      error instanceof Error
+      && ('code' in error ? error.code === 'ERR_MODULE_NOT_FOUND' : false)
+    ) {
+      console.error('Unable to import @playwright/test. Install project dependencies before starting a browser server.');
+      process.exit(1);
+    }
+
+    throw error;
+  }
+};
+
+const selectBrowserType = (playwright) => {
+  switch (browserName) {
+    case 'chromium':
+      return playwright.chromium;
+    case 'firefox':
+      return playwright.firefox;
+    case 'webkit':
+      return playwright.webkit;
+    default:
+      throw new Error(`Unsupported PLAYWRIGHT_BROWSER "${browserName}". Expected chromium, firefox, or webkit.`);
+  }
+};
+
+const persistEndpoint = async (wsEndpoint) => {
+  if (!endpointFile) {
+    return undefined;
+  }
+
+  const resolvedEndpointFile = resolve(endpointFile);
+  await mkdir(dirname(resolvedEndpointFile), { recursive: true });
+  await writeFile(resolvedEndpointFile, `${wsEndpoint}\n`, 'utf8');
+  return resolvedEndpointFile;
+};
+
+const registerShutdown = (browserServer) => {
+  let shuttingDown = false;
+
+  const closeServer = async (signal) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+
+    try {
+      await browserServer.close();
+    } finally {
+      process.exit(signal ? 0 : 1);
+    }
+  };
+
+  process.on('SIGINT', () => {
+    void closeServer('SIGINT');
+  });
+  process.on('SIGTERM', () => {
+    void closeServer('SIGTERM');
+  });
+
+  browserServer.on('close', () => {
+    if (!shuttingDown) {
+      process.exit(0);
+    }
+  });
+};
+
+const playwright = await loadPlaywright();
+const browserType = selectBrowserType(playwright);
+const browserServer = await browserType.launchServer({
+  headless: process.env.PLAYWRIGHT_HEADLESS !== '0',
+  ...(browserName === 'chromium' && playwrightChannel ? { channel: playwrightChannel } : {}),
+  ...(playwrightExecutablePath ? { executablePath: playwrightExecutablePath } : {}),
+  ...(playwrightExtraArgs.length ? { args: playwrightExtraArgs } : {}),
+  host: playwrightServerHost,
+  ...(playwrightServerPort > 0 ? { port: playwrightServerPort } : {}),
+});
+const wsEndpoint = browserServer.wsEndpoint();
+const resolvedEndpointFile = await persistEndpoint(wsEndpoint);
+
+registerShutdown(browserServer);
+
+console.log(`Playwright browser server is ready for ${browserName}.`);
+console.log(`WS endpoint: ${wsEndpoint}`);
+
+if (resolvedEndpointFile) {
+  console.log(`Endpoint file: ${resolvedEndpointFile}`);
+}
+
+console.log('Keep this process running while the sandboxed test runner connects to it.');


### PR DESCRIPTION
## Summary
- add Playwright sandbox preflight checks for localhost bind, browser launch, and websocket endpoint reachability
- support remote Playwright browser endpoints and add a host-side browser-server helper script
- document the current macOS Codex sandbox limitations and the environment changes required for Boxento E2E

## Validation
- bun run build
- node --check scripts/run-playwright.mjs
- node --check scripts/start-playwright-server.mjs
- verified fail-fast guidance for localhost bind EPERM, browser-launch SIGABRT, and loopback websocket connect EPERM cases
