### PR TITLE
[codex] Handle HTML API responses across widgets

### DIFF
--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New
 
+## May 22, 2026
+
+### 🐛 Bug Fixes
+• Widget API Errors: Replaced raw JSON parser failures like `Unexpected token '<'` with clear messages when an API endpoint returns HTML, empty content, or invalid JSON.
+• Monitoring Widgets: Uptime Kuma and Healthchecks now keep retry, settings, and delete controls available when their backend endpoint fails.
+• Docker/Self-hosted UX: Better diagnostics for misrouted backend proxies, login pages, or frontend app shells returned from widget API calls.
+
 ## December 27, 2025
 
 ### 🚀 Multi-Dashboard & Sharing
@@ -120,4 +127,4 @@
   - Flight Tracker
   - Geography Quiz
   - GitHub Streak
-  - Pomodoro Timer 
+  - Pomodoro Timer

--- a/src/components/widgets/HealthchecksWidget/index.tsx
+++ b/src/components/widgets/HealthchecksWidget/index.tsx
@@ -11,7 +11,6 @@ import {
   Timer,
   XCircle,
 } from 'lucide-react';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
@@ -25,6 +24,7 @@ import {
 } from '../../ui/select';
 import { Skeleton } from '../../ui/skeleton';
 import WidgetHeader from '../common/WidgetHeader';
+import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../common/WidgetSettingsDialog';
 import { cn } from '@/lib/utils';
 import {
   formatMonitoringItemLimitPlaceholder,
@@ -32,6 +32,7 @@ import {
   getMonitoringItemLimit,
   parseMonitoringItemLimit,
 } from '../common/monitoringItemLimit';
+import { readMonitoringJson } from '../common/monitoringApiResponse';
 import { HealthchecksCheck, HealthchecksStatus, HealthchecksWidgetConfig, HealthchecksWidgetData } from './types';
 
 const SQLITE_API_URL = import.meta.env.VITE_SQLITE_API_URL || '';
@@ -181,11 +182,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
           : undefined,
         signal: AbortSignal.timeout(10000),
       });
-      if (!response.ok) {
-        const payload = await response.json().catch(() => null);
-        throw new Error(payload?.error || `HTTP ${response.status}`);
-      }
-      const payload: HealthchecksWidgetData = await response.json();
+      const payload = await readMonitoringJson<HealthchecksWidgetData>(response, 'Healthchecks');
       setData(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch');
@@ -304,13 +301,50 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  const renderError = () => (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-sm text-muted-foreground">
-      <XCircle className="h-5 w-5 text-red-500" />
-      <span>{error}</span>
-      <Button variant="secondary" size="sm" onClick={fetchData}>Retry</Button>
-    </div>
-  );
+  const renderError = () => {
+    if (isTiny) {
+      const tinyError = (
+        <>
+          <XCircle className="h-5 w-5 text-red-500" />
+          <span className="text-[10px] font-medium text-muted-foreground">Error</span>
+        </>
+      );
+
+      if (readOnly) {
+        return (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+            {tinyError}
+          </div>
+        );
+      }
+
+      return (
+        <button
+          type="button"
+          className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md text-center"
+          onClick={() => setShowSettings(true)}
+          aria-label="Open Healthchecks settings"
+        >
+          {tinyError}
+        </button>
+      );
+    }
+
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-sm text-muted-foreground">
+        <XCircle className="h-5 w-5 text-red-500" />
+        <span className="max-w-full break-words">{error}</span>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button variant="secondary" size="sm" onClick={fetchData}>Retry</Button>
+          {!readOnly && (
+            <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>
+              Settings
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   const renderEmpty = (message: string) => (
     <div className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-sm text-muted-foreground">
@@ -584,14 +618,6 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  if (loading && !data) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderLoading()}</div>;
-  }
-
-  if (error && !data && !shouldShowSetupPrompt) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderError()}</div>;
-  }
-
   return (
     <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>
       {!isTiny && !isApp && (
@@ -603,7 +629,9 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
       )}
 
       <div className={cn('flex-1 overflow-hidden', isTiny ? 'p-1' : isApp ? '' : 'p-2 md:p-3')}>
-        {shouldShowSetupPrompt ? renderSetupPrompt()
+        {loading && !data ? renderLoading()
+          : error && !data && !shouldShowSetupPrompt ? renderError()
+          : shouldShowSetupPrompt ? renderSetupPrompt()
           : isTiny ? renderTiny()
           : isShort ? renderShort()
           : isApp ? renderApp()
@@ -612,13 +640,22 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
           : renderDefault()}
       </div>
 
-      <Dialog open={showSettings} onOpenChange={setShowSettings}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{localConfig.title || DEFAULT_CONFIG.title} Settings</DialogTitle>
-          </DialogHeader>
-          <div className="max-h-[min(60vh,500px)] overflow-y-auto py-2">
-            <div className="space-y-4 px-1">
+      <WidgetSettingsDialog
+        open={showSettings}
+        onOpenChange={setShowSettings}
+        title={`${localConfig.title || DEFAULT_CONFIG.title} Settings`}
+        description="Configure the Healthchecks instance, API key, and backend endpoint."
+        bodyClassName="py-2"
+        footer={(
+          <WidgetSettingsDialogFooter
+            onDelete={config?.onDelete}
+            deleteLabel="Delete Widget"
+            onCancel={() => setShowSettings(false)}
+            onSave={saveSettings}
+          />
+        )}
+      >
+        <div className="space-y-4 px-1">
               <div className="space-y-2">
                 <Label htmlFor="health-title">Title</Label>
                 <Input
@@ -747,20 +784,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
                 />
               </div>
             </div>
-          </div>
-          <DialogFooter>
-            <div className="flex w-full justify-between">
-              {config?.onDelete ? (
-                <Button variant="destructive" onClick={config.onDelete}>Delete Widget</Button>
-              ) : <div />}
-              <div className="ml-auto flex items-center gap-2">
-                <Button variant="outline" onClick={() => setShowSettings(false)}>Cancel</Button>
-                <Button onClick={saveSettings}>Save</Button>
-              </div>
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      </WidgetSettingsDialog>
     </div>
   );
 };

--- a/src/components/widgets/KumaWidget/index.tsx
+++ b/src/components/widgets/KumaWidget/index.tsx
@@ -8,7 +8,6 @@ import {
   Settings,
   XCircle,
 } from 'lucide-react';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
@@ -22,6 +21,7 @@ import {
 } from '../../ui/select';
 import { Skeleton } from '../../ui/skeleton';
 import WidgetHeader from '../common/WidgetHeader';
+import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../common/WidgetSettingsDialog';
 import { cn } from '@/lib/utils';
 import {
   formatMonitoringItemLimitPlaceholder,
@@ -29,6 +29,7 @@ import {
   getMonitoringItemLimit,
   parseMonitoringItemLimit,
 } from '../common/monitoringItemLimit';
+import { readMonitoringJson } from '../common/monitoringApiResponse';
 import { KumaMonitor, KumaMonitorStatus, KumaWidgetConfig, KumaWidgetData } from './types';
 
 const SQLITE_API_URL = import.meta.env.VITE_SQLITE_API_URL || '';
@@ -168,11 +169,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
           : undefined,
         signal: AbortSignal.timeout(10000),
       });
-      if (!response.ok) {
-        const payload = await response.json().catch(() => null);
-        throw new Error(payload?.error || `HTTP ${response.status}`);
-      }
-      const payload: KumaWidgetData = await response.json();
+      const payload = await readMonitoringJson<KumaWidgetData>(response, 'Uptime Kuma');
       setData(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch');
@@ -290,13 +287,50 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  const renderError = () => (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-sm text-muted-foreground">
-      <XCircle className="h-5 w-5 text-red-500" />
-      <span>{error}</span>
-      <Button variant="secondary" size="sm" onClick={fetchData}>Retry</Button>
-    </div>
-  );
+  const renderError = () => {
+    if (isTiny) {
+      const tinyError = (
+        <>
+          <XCircle className="h-5 w-5 text-red-500" />
+          <span className="text-[10px] font-medium text-muted-foreground">Error</span>
+        </>
+      );
+
+      if (readOnly) {
+        return (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+            {tinyError}
+          </div>
+        );
+      }
+
+      return (
+        <button
+          type="button"
+          className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md text-center"
+          onClick={() => setShowSettings(true)}
+          aria-label="Open Uptime Kuma settings"
+        >
+          {tinyError}
+        </button>
+      );
+    }
+
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-sm text-muted-foreground">
+        <XCircle className="h-5 w-5 text-red-500" />
+        <span className="max-w-full break-words">{error}</span>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button variant="secondary" size="sm" onClick={fetchData}>Retry</Button>
+          {!readOnly && (
+            <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>
+              Settings
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   const renderEmpty = (message: string) => (
     <div className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-sm text-muted-foreground">
@@ -564,14 +598,6 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  if (loading && !data) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderLoading()}</div>;
-  }
-
-  if (error && !data && !shouldShowSetupPrompt) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderError()}</div>;
-  }
-
   return (
     <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>
       {!isTiny && !isApp && (
@@ -583,7 +609,9 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
       )}
 
       <div className={cn('flex-1 overflow-hidden', isTiny ? 'p-1' : isApp ? '' : 'p-2 md:p-3')}>
-        {shouldShowSetupPrompt ? renderSetupPrompt()
+        {loading && !data ? renderLoading()
+          : error && !data && !shouldShowSetupPrompt ? renderError()
+          : shouldShowSetupPrompt ? renderSetupPrompt()
           : isTiny ? renderTiny()
           : isShort ? renderShort()
           : isApp ? renderApp()
@@ -592,13 +620,22 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
           : renderDefault()}
       </div>
 
-      <Dialog open={showSettings} onOpenChange={setShowSettings}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{localConfig.title || DEFAULT_CONFIG.title} Settings</DialogTitle>
-          </DialogHeader>
-          <div className="max-h-[min(60vh,500px)] overflow-y-auto py-2">
-            <div className="space-y-4 px-1">
+      <WidgetSettingsDialog
+        open={showSettings}
+        onOpenChange={setShowSettings}
+        title={`${localConfig.title || DEFAULT_CONFIG.title} Settings`}
+        description="Configure the Uptime Kuma status page and backend endpoint."
+        bodyClassName="py-2"
+        footer={(
+          <WidgetSettingsDialogFooter
+            onDelete={config?.onDelete}
+            deleteLabel="Delete Widget"
+            onCancel={() => setShowSettings(false)}
+            onSave={saveSettings}
+          />
+        )}
+      >
+        <div className="space-y-4 px-1">
               <div className="space-y-2">
                 <Label htmlFor="kuma-title">Title</Label>
                 <Input
@@ -714,20 +751,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
                 />
               </div>
             </div>
-          </div>
-          <DialogFooter>
-            <div className="flex w-full justify-between">
-              {config?.onDelete ? (
-                <Button variant="destructive" onClick={config.onDelete}>Delete Widget</Button>
-              ) : <div />}
-              <div className="ml-auto flex items-center gap-2">
-                <Button variant="outline" onClick={() => setShowSettings(false)}>Cancel</Button>
-                <Button onClick={saveSettings}>Save</Button>
-              </div>
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      </WidgetSettingsDialog>
     </div>
   );
 };

--- a/src/components/widgets/common/monitoringApiResponse.ts
+++ b/src/components/widgets/common/monitoringApiResponse.ts
@@ -1,0 +1,28 @@
+import { parseJsonResponseText } from '@/lib/jsonResponseGuard';
+
+const getPayloadMessage = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const record = payload as Record<string, unknown>;
+  const error = record.error;
+  const message = record.message;
+
+  if (typeof error === 'string' && error.trim()) return error;
+  if (typeof message === 'string' && message.trim()) return message;
+
+  return null;
+};
+
+export const readMonitoringJson = async <T>(
+  response: Response,
+  serviceName: string,
+): Promise<T> => {
+  const body = await response.text();
+  const payload = parseJsonResponseText<unknown>(body, response, `${serviceName} endpoint`);
+
+  if (!response.ok) {
+    throw new Error(getPayloadMessage(payload) || `HTTP ${response.status}`);
+  }
+
+  return payload as T;
+};

--- a/src/lib/jsonResponseGuard.ts
+++ b/src/lib/jsonResponseGuard.ts
@@ -1,0 +1,66 @@
+const HTML_RESPONSE_PATTERN = /^\s*(?:<!doctype html|<html[\s>])/i;
+const RESPONSE_JSON_GUARD_INSTALLED = Symbol.for('boxento.response-json-guard.installed');
+
+type GuardedResponsePrototype = typeof Response.prototype & {
+  [RESPONSE_JSON_GUARD_INSTALLED]?: true;
+};
+
+const getStatusLabel = (response?: Response) => {
+  if (!response || response.status === 0) return '';
+
+  return ` (HTTP ${response.status})`;
+};
+
+const getContentType = (response?: Response) => (
+  response?.headers.get('content-type')?.toLowerCase() ?? ''
+);
+
+export const getJsonResponseParseErrorMessage = (
+  body: string,
+  response?: Response,
+  sourceLabel = 'The API endpoint',
+) => {
+  const trimmedBody = body.trim();
+  const statusLabel = getStatusLabel(response);
+
+  if (!trimmedBody) {
+    return `${sourceLabel} returned an empty response instead of JSON${statusLabel}. Check the API URL or backend response.`;
+  }
+
+  const contentType = getContentType(response);
+  const returnedHtml = contentType.includes('text/html') || HTML_RESPONSE_PATTERN.test(trimmedBody);
+
+  if (returnedHtml) {
+    return `${sourceLabel} returned HTML instead of JSON${statusLabel}. Check the API URL, backend proxy, or authentication.`;
+  }
+
+  return `${sourceLabel} returned invalid JSON${statusLabel}. Check the API URL or backend response.`;
+};
+
+export const parseJsonResponseText = <T>(
+  body: string,
+  response?: Response,
+  sourceLabel?: string,
+): T => {
+  try {
+    return JSON.parse(body.trim()) as T;
+  } catch {
+    throw new SyntaxError(getJsonResponseParseErrorMessage(body, response, sourceLabel));
+  }
+};
+
+export const installJsonResponseGuard = () => {
+  if (typeof Response === 'undefined') return;
+
+  const prototype = Response.prototype as GuardedResponsePrototype;
+  if (prototype[RESPONSE_JSON_GUARD_INSTALLED]) return;
+
+  prototype.json = async function guardedJson(this: Response) {
+    const body = await this.text();
+    return parseJsonResponseText<unknown>(body, this);
+  };
+
+  Object.defineProperty(prototype, RESPONSE_JSON_GUARD_INSTALLED, {
+    value: true,
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,9 @@ import { SafeSyncProvider } from './lib/SyncContext'
 import { AppSettingsProvider } from './context/AppSettingsContext'
 import { StorageContextProvider } from './lib/storage/StorageContext'
 import { SharedDashboardView } from './components/dashboard/SharedDashboardView'
+import { installJsonResponseGuard } from './lib/jsonResponseGuard'
+
+installJsonResponseGuard()
 
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Failed to find the root element')

--- a/tests/e2e/monitoring-widgets.spec.ts
+++ b/tests/e2e/monitoring-widgets.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+import { seedDashboard } from './helpers/dashboardSeed';
+
+test('monitoring widgets explain HTML API responses and keep settings reachable', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  await page.route('**/api/monitoring/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<!doctype html><html><body>Boxento app shell</body></html>',
+    });
+  });
+  await page.route('**/api/cron-health-html', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<!doctype html><html><body>Boxento app shell</body></html>',
+    });
+  });
+
+  await seedDashboard(page, {
+    widgets: [
+      { id: 'kuma-1', type: 'kuma', config: { title: 'Service Monitoring' } },
+      { id: 'healthchecks-1', type: 'healthchecks', config: { title: 'Job Monitoring' } },
+      { id: 'cron-health-1', type: 'cron-health', config: { title: 'System Health', apiUrl: '/api/cron-health-html' } },
+    ],
+    layouts: {
+      lg: [
+        { i: 'kuma-1', x: 0, y: 0, w: 3, h: 4, minW: 2, minH: 2 },
+        { i: 'healthchecks-1', x: 3, y: 0, w: 3, h: 4, minW: 2, minH: 2 },
+        { i: 'cron-health-1', x: 6, y: 0, w: 3, h: 4, minW: 2, minH: 2 },
+      ],
+    },
+  });
+
+  const kuma = page.locator('.react-grid-item[data-widget-id="kuma-1"]');
+  await expect(kuma.getByText('Uptime Kuma endpoint returned HTML instead of JSON')).toBeVisible();
+  await kuma.getByRole('button', { name: 'Settings', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: 'Service Monitoring Settings' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete Widget' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  const healthchecks = page.locator('.react-grid-item[data-widget-id="healthchecks-1"]');
+  await expect(healthchecks.getByText('Healthchecks endpoint returned HTML instead of JSON')).toBeVisible();
+  await healthchecks.getByRole('button', { name: 'Settings', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: 'Job Monitoring Settings' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete Widget' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  const cronHealth = page.locator('.react-grid-item[data-widget-id="cron-health-1"]');
+  await expect(cronHealth.getByText('The API endpoint returned HTML instead of JSON')).toBeVisible();
+});

--- a/tests/unit/jsonResponseGuard.test.ts
+++ b/tests/unit/jsonResponseGuard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getJsonResponseParseErrorMessage,
+  installJsonResponseGuard,
+  parseJsonResponseText,
+} from '@/lib/jsonResponseGuard';
+
+describe('jsonResponseGuard', () => {
+  it('parses valid JSON text', () => {
+    expect(parseJsonResponseText<{ ok: boolean }>('{"ok":true}')).toEqual({ ok: true });
+  });
+
+  it('identifies HTML responses without exposing query strings', () => {
+    const response = new Response('<!doctype html><html><body>Login</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+
+    expect(getJsonResponseParseErrorMessage('<!doctype html>', response, 'Widget API')).toBe(
+      'Widget API returned HTML instead of JSON (HTTP 200). Check the API URL, backend proxy, or authentication.',
+    );
+  });
+
+  it('makes response.json failures readable app-wide', async () => {
+    installJsonResponseGuard();
+
+    const response = new Response('<html><body>Not JSON</body></html>', {
+      status: 404,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    await expect(response.json()).rejects.toThrow(
+      'The API endpoint returned HTML instead of JSON (HTTP 404). Check the API URL, backend proxy, or authentication.',
+    );
+  });
+});

--- a/tests/unit/monitoringApiResponse.test.ts
+++ b/tests/unit/monitoringApiResponse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { readMonitoringJson } from '@/components/widgets/common/monitoringApiResponse';
+
+describe('readMonitoringJson', () => {
+  it('returns parsed JSON for successful monitoring responses', async () => {
+    const response = new Response(JSON.stringify({ monitors: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(readMonitoringJson<{ monitors: unknown[] }>(response, 'Uptime Kuma')).resolves.toEqual({
+      monitors: [],
+    });
+  });
+
+  it('uses JSON error payloads from failed responses', async () => {
+    const response = new Response(JSON.stringify({ error: 'Monitoring is not configured' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(readMonitoringJson(response, 'Healthchecks')).rejects.toThrow('Monitoring is not configured');
+  });
+
+  it('explains when a frontend HTML page is returned instead of widget API JSON', async () => {
+    const response = new Response('<!doctype html><html><body>Boxento</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    await expect(readMonitoringJson(response, 'Uptime Kuma')).rejects.toThrow(
+      'Uptime Kuma endpoint returned HTML instead of JSON',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces raw `Unexpected token '<'` JSON parser failures with clear API-response diagnostics for HTML, empty, and invalid JSON responses.
- Updates Uptime Kuma and Healthchecks to use a shared monitoring response reader and keep Retry, Settings, and Delete available in error states.
- Installs an app-wide `Response.json()` guard so other widgets that still call `response.json()` also surface readable JSON-response errors.
- Adds unit and e2e coverage plus a changelog entry for Docker/self-hosted users.

## PM-ready impact
- Users see a clear setup/proxy/authentication hint when a widget endpoint returns the frontend HTML page or login HTML instead of JSON.
- Kuma and Healthchecks users can recover from the error without losing access to widget settings or delete controls.
- Other widgets using plain `response.json()` get safer app-wide error messages without per-widget edits.
- No database, backend, or volume migration is required.

## Validation
- `bun run build:types`
- `bun run test`
- `bun run lint` (passes with existing 64 warnings)
- `PLAYWRIGHT_CHANNEL=chrome node scripts/run-playwright.mjs tests/e2e/monitoring-widgets.spec.ts`
- `PLAYWRIGHT_CHANNEL=chrome node scripts/run-playwright.mjs --workers=1`
- `bun run build`
