### PR TITLE
Improve dashboard performance and widget resilience

### DIFF
--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: commit
+description:
+  Create a well-formed git commit from current changes using session history for
+  rationale and summary; use when asked to commit, prepare a commit message, or
+  finalize staged work.
+---
+
+# Commit
+
+## Goals
+
+- Produce a commit that reflects the actual code changes and the session context.
+- Follow common git conventions with a concise subject and wrapped body.
+- Include both summary and rationale in the body.
+
+## Inputs
+
+- Codex session history for intent and rationale.
+- `git status`, `git diff`, and `git diff --staged` for actual changes.
+- Repo-specific commit conventions if documented.
+
+## Steps
+
+1. Read session history to identify scope, intent, and rationale.
+2. Inspect the working tree and staged changes.
+3. Stage intended changes, including new files, after confirming scope.
+4. Sanity-check newly added files and flag anything that looks like an artifact, log, or temp file.
+5. If staging is incomplete or includes unrelated files, fix the index or ask for confirmation.
+6. Choose a conventional type and optional scope that match the change.
+7. Write a subject line in imperative mood, 72 characters or fewer, without a trailing period.
+8. Write a body that includes:
+   - Summary of key changes.
+   - Rationale and trade-offs.
+   - Tests or validation run, or an explicit note if not run.
+9. Append a `Co-authored-by` trailer for Codex using `Codex <codex@openai.com>` unless the user explicitly requests a different identity.
+10. Wrap body lines at 72 characters.
+11. Create the commit with `git commit -F <file>` or equivalent so newlines are literal.
+12. Ensure the message matches the staged changes before committing.
+
+## Template
+
+```text
+<type>(<scope>): <short summary>
+
+Summary:
+- <what changed>
+- <what changed>
+
+Rationale:
+- <why>
+- <why>
+
+Tests:
+- <command or "not run (reason)">
+
+Co-authored-by: Codex <codex@openai.com>
+```
+

--- a/.codex/skills/land/SKILL.md
+++ b/.codex/skills/land/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: land
+description:
+  Land a PR by monitoring conflicts, resolving them, waiting for checks, and
+  squash-merging when green; use when asked to land, merge, or shepherd a PR to
+  completion.
+---
+
+# Land
+
+## Goals
+
+- Ensure the PR is conflict-free with `main`.
+- Keep CI green and fix failures when they occur.
+- Squash-merge the PR once checks pass.
+- Do not yield until the PR is merged unless blocked.
+
+## Preconditions
+
+- `gh` CLI is authenticated.
+- You are on the PR branch with a clean working tree.
+
+## Steps
+
+1. Locate the PR for the current branch.
+2. Confirm the full gauntlet is green locally before any push:
+   - `bun run lint`
+   - `bun run test`
+   - `bun run test:e2e` for user-facing changes
+3. If the working tree has uncommitted changes, commit with the `commit` skill and push with the `push` skill before proceeding.
+4. Check mergeability and conflicts against `main`.
+5. If conflicts exist, use the `pull` skill to merge `origin/main`, resolve conflicts, and then use the `push` skill to publish the updated branch.
+6. Ensure review comments are acknowledged and any required fixes are handled before merging.
+7. Watch checks until complete.
+8. If checks fail, inspect logs, fix the issue, commit, push, and restart the watch.
+9. When all checks are green and review feedback is addressed, squash-merge the PR.
+
+## Commands
+
+```sh
+branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number -q .number)
+pr_title=$(gh pr view --json title -q .title)
+pr_body=$(gh pr view --json body -q .body)
+mergeable=$(gh pr view --json mergeable -q .mergeable)
+
+if [ "$mergeable" = "CONFLICTING" ]; then
+  echo "Run the pull skill, resolve conflicts, then push the branch again."
+  exit 1
+fi
+
+python3 .codex/skills/land/land_watch.py
+
+gh pr merge --squash --subject "$pr_title" --body "$pr_body"
+```
+
+## Failure handling
+
+- If checks fail, inspect `gh pr checks` and `gh run view --log`, fix the issue locally, commit, push, and rerun the watch.
+- If mergeability is `UNKNOWN`, wait and re-check.
+- Do not merge while actionable review comments remain unresolved.
+

--- a/.codex/skills/land/land_watch.py
+++ b/.codex/skills/land/land_watch.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import random
+from dataclasses import dataclass
+
+POLL_SECONDS = 10
+MAX_GH_RETRIES = 5
+BASE_GH_BACKOFF_SECONDS = 2
+
+
+@dataclass
+class PrInfo:
+    number: int
+    url: str
+    head_sha: str
+    mergeable: str | None
+    merge_state: str | None
+
+
+class RateLimitError(RuntimeError):
+    pass
+
+
+def is_rate_limit_error(error: str) -> bool:
+    return "HTTP 429" in error or "rate limit" in error.lower()
+
+
+async def run_gh(*args: str) -> str:
+    max_delay = BASE_GH_BACKOFF_SECONDS * (2 ** (MAX_GH_RETRIES - 1))
+    delay_seconds = BASE_GH_BACKOFF_SECONDS
+    last_error = "gh command failed"
+    for attempt in range(1, MAX_GH_RETRIES + 1):
+        proc = await asyncio.create_subprocess_exec(
+            "gh",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode == 0:
+            return stdout.decode()
+        error = stderr.decode().strip() or "gh command failed"
+        if not is_rate_limit_error(error):
+            raise RuntimeError(error)
+        last_error = error
+        if attempt >= MAX_GH_RETRIES:
+            break
+        jitter = random.uniform(0, delay_seconds)
+        await asyncio.sleep(min(delay_seconds + jitter, max_delay))
+        delay_seconds = min(delay_seconds * 2, max_delay)
+    raise RateLimitError(last_error)
+
+
+async def get_pr_info() -> PrInfo:
+    data = await run_gh(
+        "pr",
+        "view",
+        "--json",
+        "number,url,headRefOid,mergeable,mergeStateStatus",
+    )
+    parsed = json.loads(data)
+    return PrInfo(
+        number=parsed["number"],
+        url=parsed["url"],
+        head_sha=parsed["headRefOid"],
+        mergeable=parsed.get("mergeable"),
+        merge_state=parsed.get("mergeStateStatus"),
+    )
+
+
+async def get_check_runs(head_sha: str) -> list[dict]:
+    data = await run_gh(
+        "api",
+        "--method",
+        "GET",
+        f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs",
+    )
+    payload = json.loads(data)
+    return payload.get("check_runs", [])
+
+
+def summarize_checks(check_runs: list[dict]) -> tuple[bool, bool]:
+    if not check_runs:
+      return True, False
+    pending = False
+    failed = False
+    for check in check_runs:
+        status = check.get("status")
+        conclusion = check.get("conclusion")
+        if status != "completed":
+            pending = True
+            continue
+        if conclusion not in ("success", "skipped", "neutral"):
+            failed = True
+    return pending, failed
+
+
+async def main() -> int:
+    while True:
+        info = await get_pr_info()
+        if info.mergeable == "CONFLICTING":
+            print("PR is conflicting with main.")
+            return 1
+        checks = await get_check_runs(info.head_sha)
+        pending, failed = summarize_checks(checks)
+        if failed:
+            print("PR checks failed.")
+            return 3
+        if not pending:
+            print("PR checks are complete.")
+            return 0
+        await asyncio.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/.codex/skills/linear/SKILL.md
+++ b/.codex/skills/linear/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: linear
+description: |
+  Use Symphony's `linear_graphql` client tool for raw Linear GraphQL
+  operations such as comment editing and status updates.
+---
+
+# Linear GraphQL
+
+Use this skill for raw Linear GraphQL work during Symphony app-server sessions.
+
+## Primary tool
+
+Use the `linear_graphql` client tool exposed by Symphony's app-server session.
+It reuses Symphony's configured Linear auth for the session.
+
+Tool input:
+
+```json
+{
+  "query": "query or mutation document",
+  "variables": {
+    "optional": "graphql variables object"
+  }
+}
+```
+
+## Operating rules
+
+- Send one GraphQL operation per tool call.
+- Treat a top-level `errors` array as a failed GraphQL operation even if the tool call itself completed.
+- Keep queries and mutations narrowly scoped.
+
+## Common workflows
+
+### Query an issue by key
+
+```graphql
+query IssueByKey($key: String!) {
+  issue(id: $key) {
+    id
+    identifier
+    title
+    url
+    description
+    branchName
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+  }
+}
+```
+
+### Query a team's workflow states
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    id
+    team {
+      id
+      key
+      name
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+### Update an issue state
+
+```graphql
+mutation MoveIssue($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      identifier
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+### Update an existing comment
+
+```graphql
+mutation UpdateComment($id: String!, $body: String!) {
+  commentUpdate(id: $id, input: { body: $body }) {
+    success
+    comment {
+      id
+      body
+    }
+  }
+}
+```
+

--- a/.codex/skills/pull/SKILL.md
+++ b/.codex/skills/pull/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: pull
+description:
+  Pull latest origin/main into the current local branch and resolve merge
+  conflicts (aka update-branch). Use when Codex needs to sync a feature branch
+  with origin, perform a merge-based update, and resolve conflicts safely.
+---
+
+# Pull
+
+## Workflow
+
+1. Verify the git status is clean or commit/stash changes before merging.
+2. Ensure rerere is enabled locally:
+   - `git config rerere.enabled true`
+   - `git config rerere.autoupdate true`
+3. Confirm remotes and branches:
+   - Ensure the `origin` remote exists.
+   - Ensure the current branch is the one to receive the merge.
+4. Fetch latest refs:
+   - `git fetch origin`
+5. Sync the remote feature branch first:
+   - `git pull --ff-only origin $(git branch --show-current)`
+6. Merge `origin/main`:
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/main`
+7. If conflicts appear, resolve them, then stage the resolved files and complete the merge.
+8. Verify with project checks appropriate to the scope.
+9. Summarize the merge, including the main conflicts and how they were resolved.
+
+## Conflict guidance
+
+- Inspect context before editing with `git status`, `git diff`, and file-level diffs.
+- Decide the final behavior before editing conflict markers.
+- Prefer minimal, intention-preserving edits.
+- Resolve one file at a time and rerun checks after each logical batch.
+- For generated files, resolve source conflicts first and regenerate if needed.
+- After resolving, ensure no conflict markers remain with `git diff --check`.
+
+## Ask the user only when necessary
+
+Ask only when the correct resolution depends on product intent that is not inferable from code, tests, or nearby documentation, or when the conflict would introduce irreversible risk without an obvious safe default.
+

--- a/.codex/skills/push/SKILL.md
+++ b/.codex/skills/push/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: push
+description:
+  Push current branch changes to origin and create or update the corresponding
+  pull request; use when asked to push, publish updates, or create a pull request.
+---
+
+# Push
+
+## Prerequisites
+
+- `gh` CLI is installed and available in `PATH`.
+- `gh auth status` succeeds for GitHub operations in this repo.
+
+## Goals
+
+- Push current branch changes to `origin` safely.
+- Create a PR if none exists for the branch, otherwise update the existing PR.
+- Keep branch history clean when remote has moved.
+
+## Related skills
+
+- `pull`: use this when push is rejected or the branch is stale.
+
+## Validation gate
+
+Run the checks that match the repo's normal contribution flow before pushing:
+
+```sh
+bun run lint
+bun run test
+```
+
+Run browser coverage too when the change is user-facing, routing-related, or otherwise browser-observable:
+
+```sh
+bun run test:e2e
+```
+
+If Playwright browsers are missing, install them first:
+
+```sh
+bunx playwright install --with-deps chromium
+```
+
+## Steps
+
+1. Identify the current branch and confirm the remote state.
+2. Run the required validation for the scope.
+3. Push the branch to `origin` with upstream tracking if needed.
+4. If push is rejected because the remote moved, run the `pull` skill, rerun validation, and push again.
+5. If push fails because of auth, permissions, or repo rules, stop and surface the exact error.
+6. Ensure a PR exists for the branch:
+   - If no PR exists, create one.
+   - If a PR exists and is open, update it.
+   - If the current branch is tied to a closed or merged PR, create a fresh branch and PR.
+7. Write or update a clear PR title and body that match the current diff.
+8. Reply with the PR URL from `gh pr view`.
+
+## Commands
+
+```sh
+branch=$(git branch --show-current)
+
+git push -u origin HEAD
+
+pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
+if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+  echo "Current branch is tied to a closed PR; create a new branch + PR." >&2
+  exit 1
+fi
+
+pr_title="<clear PR title written for this change>"
+if [ -z "$pr_state" ]; then
+  gh pr create --fill --title "$pr_title"
+else
+  gh pr edit --title "$pr_title"
+fi
+
+gh pr view --json url -q .url
+```
+
+## Notes
+
+- Do not use `--force`; use `--force-with-lease` only when local history was intentionally rewritten.
+- Distinguish sync problems from auth or permission problems. Use the `pull` skill for the former and surface the latter directly.
+

--- a/.codex/worktree_init.sh
+++ b/.codex/worktree_init.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun is required but was not found on PATH." >&2
+  exit 1
+fi
+
+bun install --frozen-lockfile
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,18 +4,22 @@
 
 # Dependencies
 node_modules
+**/node_modules
 .npm
 .yarn
 
 # Build outputs
 dist
 build
+output
+test-results
 *.tsbuildinfo
 
 # Environment and secrets
 .env
 .env.*
 !.env.example
+.firebase
 
 # Development files
 *.log
@@ -40,4 +44,4 @@ Dockerfile*
 # Documentation
 README.md
 CHANGELOG.md
-docs/ 
+docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Do not simply scale the same crowded UI up or down.
 - Use compact header spacing only when the widget is short or dense enough that the default header would crowd the content.
 - Use a clear, short title that matches the widget's user value.
 - Keep header actions minimal. The settings button is standard; add other actions only when they are truly primary.
+- In one-column, tiny, or short-row sizes, do not show clipped titles such as `Weat...`. Hide the outer header and expose settings through a size-appropriate overlay/control when the standard header cannot fit.
 
 ### Size Rules
 
@@ -139,6 +140,7 @@ Support these states intentionally:
 - Reduce chrome in smaller sizes and increase capability in larger ones.
 - Keep text wrapping and truncation deliberate.
 - Avoid accidental overflow, clipped controls, and stacked scrollbars.
+- Audit narrow states for clipped headings and wide/4K states for wasted dashboard canvas.
 - Avoid fixed pixel heights that break grid resizing.
 - Use theme tokens and semantic utility classes instead of ad hoc colors.
 - Introduce custom colors only when the data itself is semantic, such as status or category encoding.
@@ -161,11 +163,14 @@ Support these states intentionally:
 
 Use this checklist when reviewing a widget:
 
+- Did the change preserve existing visual styling unless it is explicitly fixing overflow, clipping, or broken recovery?
 - Does the widget have a deliberate tiny, compact, standard, and large-surface story for the sizes it claims to support?
 - Does it use the shared shell and settings primitives unless there is a good reason not to?
 - Does the header remain borderless and visually integrated?
 - Does it handle loading, empty, error, configured, and read-only states cleanly?
 - Does the settings flow keep destructive actions in the standard footer pattern?
+- Do one-column, tiny, and short-row states avoid clipped titles and overlapping controls?
+- Does the dashboard use the available canvas on wide/4K displays without forcing a laptop-width grid?
 - Does it avoid custom spacing and color systems that drift away from the rest of Boxento?
 - If it supports `1x1`, was `TINY_READY_WIDGET_TYPES` updated?
 
@@ -181,6 +186,8 @@ When summarizing widget UX changes, include a short PM-ready section covering:
 Use concise, testable statements such as:
 
 - The widget shows a glanceable tiny state without overflow or hidden critical text.
+- Narrow widget states avoid clipped titles or overlapping controls.
+- Performance changes do not add new hover effects, shadows, borders, or visual treatments.
 - The compact state preserves the primary job of the widget and removes secondary clutter.
 - The standard state exposes the main workflow and settings entry point.
 - The large or app state expands into richer controls or detail views only when they improve the workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,188 @@
+# AI Agent Instructions
+
+When you provide instructions in addition to technical stuff, also include product manager ready instructions.
+
+## Boxento Widget UX Contract
+
+Use this file as the source of truth when creating, updating, or reviewing Boxento widgets.
+
+### Source Of Truth In Code
+
+Read these files before making widget UX decisions:
+
+- `docs/WIDGET_DEVELOPMENT.md`
+- `src/components/widgets/common/WidgetShell.tsx`
+- `src/components/widgets/common/WidgetSettingsDialog.tsx`
+- `src/components/widgets/common/widgetHeaderStyles.ts`
+- `src/components/dashboard/DashboardWidgetFrame.tsx`
+- `src/components/widgets/index.ts`
+
+Use these widgets as implementation anchors for size-spectrum behavior:
+
+- `src/components/widgets/TodoWidget/index.tsx`
+- `src/components/widgets/NotesWidget/index.tsx`
+- `src/components/widgets/WeatherWidget/index.tsx`
+- `src/components/widgets/QuickLinksWidget/index.tsx`
+- `src/components/widgets/RSSWidget/index.tsx`
+
+### Core Principle
+
+Design every widget as a size spectrum, not a single squeezed layout:
+
+1. `1x1` glance state
+2. compact widget state
+3. standard widget state
+4. panel state
+5. app state
+
+As the widget gets larger, reveal more workflow, context, and controls.
+Do not simply scale the same crowded UI up or down.
+
+### Shell Rules
+
+- Prefer `WidgetShell` for new or heavily refactored widgets.
+- Keep the root layout aligned with Boxento's flex model: `widget-container`, `flex`, `h-full`, `flex-col`.
+- Keep the content area resilient to resizing with `min-h-0`, `flex-1`, and deliberate overflow behavior.
+- Use `contentClassName` on `WidgetShell` to adjust density by size instead of creating a second shell system.
+- Keep the header visually integrated with content. Do not add a bottom border or separator line under the header.
+- Keep the settings entry point in the header unless the widget is tiny or fully app-sized and the app layout already has a clearer control surface.
+
+### Header Rules
+
+- Hide the outer header in tiny mode.
+- Prefer hiding the outer header in app mode when the app surface has its own title, toolbar, tabs, or filters.
+- Use compact header spacing only when the widget is short or dense enough that the default header would crowd the content.
+- Use a clear, short title that matches the widget's user value.
+- Keep header actions minimal. The settings button is standard; add other actions only when they are truly primary.
+
+### Size Rules
+
+#### Tiny: `width === 1 && height === 1`
+
+- Show one glanceable signal, one icon-led cue, or one tap target.
+- Do not render dense forms, lists, or multiple competing actions.
+- Do not render the standard header.
+- Keep text extremely short and centered or intentionally aligned.
+- If the only useful action is setup, opening settings from the tiny surface is acceptable.
+
+#### Short Row: `height === 1 && width > 1`
+
+- Use a compact header or compact inline summary.
+- Show one-line status, metric, or next action.
+- Avoid multi-line content that will overflow vertically.
+
+#### Compact: typically `width <= 2` or `height <= 2`
+
+- Prioritize the primary status or one small workflow.
+- Reduce metadata and secondary controls.
+- Favor truncation, chips, counters, or compact list items over paragraphs.
+- Avoid tables, large forms, and nested panels.
+
+#### Standard: typical default widget sizes
+
+- Show the primary workflow clearly.
+- Include the most important controls and enough context to understand the data.
+- Keep density moderate and scanning easy.
+
+#### Panel And App: typically `width >= 4 && height >= 4`, especially `width >= 6 && height >= 6`
+
+- Expand into search, filters, tabs, secondary metadata, detail panes, inline editing, or richer previews when the widget's job benefits from them.
+- Promote app-specific controls only when the larger surface materially improves the workflow.
+- Avoid leaving large surfaces visually empty just because the small widget layout was stretched.
+
+### State Rules
+
+Support these states intentionally:
+
+- loading
+- empty
+- error
+- configured success
+- read-only
+
+#### Loading
+
+- Rely on the dashboard `Suspense` fallback for component-load time.
+- Use skeletons or subtle in-widget loading states for data refreshes, not full-screen spinners by default.
+- Keep loading layout close to final layout to reduce visual jump.
+
+#### Empty
+
+- Explain what is missing in plain language.
+- Offer the next step: configure, add an item, connect an account, or choose a source.
+- Keep empty states calm and informative instead of decorative.
+
+#### Error
+
+- Show a scoped message tied to the failed task.
+- Offer a recovery path when possible: retry, reconfigure, reconnect, or inspect settings.
+- Do not dump raw error objects into the widget UI.
+
+#### Read-Only
+
+- Respect `config.readOnly` as a first-class mode.
+- Hide settings, editing, creation, reorder, and destructive controls when the widget is read-only.
+- Keep the widget fully legible and useful even when interaction is suppressed.
+
+### Settings Rules
+
+- Prefer `WidgetSettingsDialog` and `WidgetSettingsDialogFooter` for configuration flows.
+- Keep draft form state local until Save when multiple fields are involved.
+- Use immediate persistence only when the widget already has a stable inline editing pattern and the interaction is core to the widget.
+- Put destructive actions in the footer using the destructive button variant.
+- Route delete flows through `config.onDelete` and save flows through `config.onUpdate`.
+- Do not hide core operational workflow inside settings if the user needs that action frequently in normal use.
+
+### Content Rules
+
+- Make the primary task obvious within two seconds of looking at the widget.
+- Reduce chrome in smaller sizes and increase capability in larger ones.
+- Keep text wrapping and truncation deliberate.
+- Avoid accidental overflow, clipped controls, and stacked scrollbars.
+- Avoid fixed pixel heights that break grid resizing.
+- Use theme tokens and semantic utility classes instead of ad hoc colors.
+- Introduce custom colors only when the data itself is semantic, such as status or category encoding.
+
+### Registry Rules
+
+- Set `defaultWidth`, `defaultHeight`, `minWidth`, and `minHeight` according to the real UX requirements of the widget.
+- Only mark a widget as tiny-ready by adding it to `TINY_READY_WIDGET_TYPES` when it has a real `1x1` design.
+- Keep registry descriptions user-facing and outcome-oriented.
+
+### Accessibility And Interaction Rules
+
+- Use proper button, input, and dialog labels.
+- Keep keyboard access intact for primary actions.
+- Avoid putting important click targets on drag-only surfaces without clear affordance.
+- Stop propagation only where needed to protect dashboard interactions, not as a blanket pattern.
+- Prefer shared UI primitives so focus states and semantics stay consistent.
+
+### Review Checklist
+
+Use this checklist when reviewing a widget:
+
+- Does the widget have a deliberate tiny, compact, standard, and large-surface story for the sizes it claims to support?
+- Does it use the shared shell and settings primitives unless there is a good reason not to?
+- Does the header remain borderless and visually integrated?
+- Does it handle loading, empty, error, configured, and read-only states cleanly?
+- Does the settings flow keep destructive actions in the standard footer pattern?
+- Does it avoid custom spacing and color systems that drift away from the rest of Boxento?
+- If it supports `1x1`, was `TINY_READY_WIDGET_TYPES` updated?
+
+### PM-Ready Acceptance Criteria Template
+
+When summarizing widget UX changes, include a short PM-ready section covering:
+
+- which widget sizes changed
+- what the user sees in each size
+- what changed in settings or destructive flows
+- how loading, empty, error, and read-only states behave
+
+Use concise, testable statements such as:
+
+- The widget shows a glanceable tiny state without overflow or hidden critical text.
+- The compact state preserves the primary job of the widget and removes secondary clutter.
+- The standard state exposes the main workflow and settings entry point.
+- The large or app state expands into richer controls or detail views only when they improve the workflow.
+- Loading, empty, error, and read-only states are understandable without reading code.
+- Destructive actions remain inside settings and use the standard confirmation path.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ FROM base AS deps
 WORKDIR /app
 
 # Copy package files
-COPY package.json ./
+COPY package.json bun.lock ./
 
-# Install dependencies and generate lockfile
-RUN bun install
+# Install dependencies from the committed lockfile
+RUN bun install --frozen-lockfile
 
 # Stage 3: Builder
 FROM deps AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ ARG VITE_SERVICES_BASE_URL="http://localhost"
 # SQLite backend URL for self-hosted mode (e.g., "http://mini:3001/api")
 ARG VITE_SQLITE_API_URL=""
 
+# Build version shown in the footer. Pass `--build-arg VITE_BUILD_HASH=$(git rev-parse --short HEAD)`.
+ARG VITE_BUILD_HASH="docker"
+
 # Create .env file for build time using heredoc for readability
 RUN <<EOF cat > .env
 VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY
@@ -45,6 +48,7 @@ VITE_FIREBASE_MESSAGING_SENDER_ID=$VITE_FIREBASE_MESSAGING_SENDER_ID
 VITE_FIREBASE_APP_ID=$VITE_FIREBASE_APP_ID
 VITE_SERVICES_BASE_URL=$VITE_SERVICES_BASE_URL
 VITE_SQLITE_API_URL=$VITE_SQLITE_API_URL
+VITE_BUILD_HASH=$VITE_BUILD_HASH
 EOF
 
 # Build the application

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,183 @@
+---
+# Minimum recommended Linear states for this workflow:
+# - Todo
+# - In Progress
+# - In Review
+# - Done
+# If your team uses different labels, replace the state names below.
+tracker:
+  kind: linear
+  project_slug: "boxento-40fc92f12c05"
+  active_states:
+    - Todo
+    - In Progress
+    - In Review
+  terminal_states:
+    - Done
+    - Cancelled
+    - Canceled
+    - Duplicate
+polling:
+  interval_ms: 5000
+workspace:
+  root: ~/code/symphony-workspaces/boxento
+hooks:
+  after_create: |
+    git clone --depth 1 https://github.com/sushaantu/boxento.git .
+    ./.codex/worktree_init.sh
+agent:
+  max_concurrent_agents: 5
+  max_turns: 20
+codex:
+  command: codex --config shell_environment_policy.inherit=all --config model_reasoning_effort=xhigh --model gpt-5.3-codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+---
+
+You are working on a Linear ticket `{{ issue.identifier }}` for the Boxento app.
+
+{% if attempt %}
+Continuation context:
+
+- This is retry attempt #{{ attempt }} because the ticket is still in an active state.
+- Resume from the current workspace state instead of restarting from scratch.
+- Do not repeat already-completed investigation or validation unless needed for new code changes.
+- Do not end the turn while the ticket remains in an active state unless blocked by missing required permissions, auth, or secrets.
+{% endif %}
+
+Issue context:
+Identifier: {{ issue.identifier }}
+Title: {{ issue.title }}
+Current status: {{ issue.state }}
+Labels: {{ issue.labels }}
+URL: {{ issue.url }}
+
+Description:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+
+Instructions:
+
+1. This is an unattended orchestration session. Never ask a human to perform follow-up actions unless blocked by missing required access or secrets.
+2. Final messages should report completed actions and blockers only. Do not include "next steps for user".
+3. Work only in the provided repository copy. Do not touch any other path.
+
+## Repo specifics
+
+- Package manager: `bun`
+- Primary app root: repository root
+- Local development server: `bun run dev`
+- Validation baseline: `bun run lint`, `bun run test`, `bun run test:e2e`
+- Boxento supports local-only mode. Firebase-related env vars are optional unless the task explicitly touches cloud sync or auth flows.
+
+## Linear tool requirement
+
+The agent should be able to talk to Linear, either via a configured Linear MCP server or Symphony's injected `linear_graphql` tool. If neither is present, stop and report that Linear integration is missing.
+
+## Default posture
+
+- Start by determining the ticket's current status and route to the matching flow.
+- Use a single persistent `## Codex Workpad` comment as the source of truth for progress and validation.
+- Reproduce first whenever there is an existing bug or failing behavior.
+- Keep issue metadata current and keep the workpad updated after each meaningful milestone.
+- Treat ticket-authored `Validation`, `Test Plan`, or `Testing` sections as required acceptance input.
+- Keep scope tight. If you find additional worthwhile work, open a follow-up Linear ticket instead of expanding the current one.
+
+## Related skills
+
+- `linear`: interact with Linear through raw GraphQL operations.
+- `commit`: produce a clean commit with rationale.
+- `pull`: merge the latest `origin/main` into the branch when needed.
+- `push`: publish the branch and create or update the PR.
+- `land`: merge an approved PR after checks pass.
+
+## Status map
+
+- `Backlog` or other non-active planning states -> out of scope for this workflow; do not modify.
+- `Todo` -> queued; immediately transition to `In Progress` before active work.
+- `In Progress` -> implementation actively underway.
+- `In Review` -> a PR should exist; wait for human review, address review feedback if present, and merge only after approval plus green checks.
+- `Done` -> terminal state; no further action required.
+
+If your Linear team uses different names, update both the YAML front matter and these status references before running Symphony.
+
+## Step 0: Determine current ticket state and route
+
+1. Fetch the issue by explicit ticket ID.
+2. Read the current state.
+3. Route to the matching flow:
+   - `Todo` -> move to `In Progress`, then begin execution.
+   - `In Progress` -> continue execution flow.
+   - `In Review` -> do not start new feature work; first inspect PR status and review feedback.
+   - `Done` or any terminal state -> do nothing and shut down.
+   - Any other non-active state -> stop and wait for a human to move the ticket into an active state.
+4. Check whether a PR already exists for the current branch and whether it is closed.
+   - If a branch PR exists and is `CLOSED` or `MERGED`, create a fresh branch from `origin/main` before resuming implementation.
+
+## Step 1: Start or continue execution
+
+1. Find or create a single persistent scratchpad comment for the issue with the header `## Codex Workpad`.
+2. Reconcile the workpad before any new edits:
+   - Check off items already completed.
+   - Update the plan so it reflects the actual remaining scope.
+   - Ensure `Acceptance Criteria` and `Validation` sections are current.
+3. Include a compact environment stamp near the top:
+   - Format: `<host>:<abs-workdir>@<short-sha>`
+4. Add or update checklist sections for:
+   - Plan
+   - Acceptance Criteria
+   - Validation
+   - Notes
+5. Capture a concrete reproduction signal before implementation when applicable.
+6. Sync with `origin/main` before code edits if the branch is stale or if the ticket resumes after time away.
+
+## Step 2: Execution phase
+
+1. Determine current repo state: branch, `git status`, and `HEAD`.
+2. Implement against the workpad checklist and keep the comment current as reality changes.
+3. Run validation appropriate to the scope.
+   - Minimum default validation for app changes: `bun run lint`, `bun run test`
+   - Run `bun run test:e2e` for user-facing flow changes, routing changes, widget behavior changes, or other browser-observable work.
+4. Before every `git push`, rerun the required validation for the current scope.
+5. Ensure a PR exists for the branch and attach its URL to the Linear issue.
+6. Move the ticket to `In Review` only when:
+   - required validation is complete,
+   - the PR is updated,
+   - the workpad reflects the final plan and validation state.
+
+## PR feedback sweep protocol
+
+When a ticket has an attached PR, gather feedback from all channels before considering the work ready:
+
+1. Top-level PR comments.
+2. Inline review comments.
+3. Review summaries and approval state.
+
+Treat every actionable reviewer comment as blocking until it is either addressed in code or answered with explicit, justified pushback.
+
+## Step 3: In Review handling
+
+1. When the issue is in `In Review`, do not continue feature work by default.
+2. Poll the PR for review state, review comments, and CI checks.
+3. If review feedback requests changes:
+   - reply inline,
+   - move the issue back to `In Progress`,
+   - implement the requested changes,
+   - rerun validation,
+   - update the PR,
+   - return the issue to `In Review`.
+4. If approval is present and checks are green, use the `land` skill to merge the PR.
+5. After merge succeeds, move the issue to `Done`.
+
+## Completion bar before moving to In Review
+
+- The implementation matches the ticket scope.
+- Required validation is complete and recorded in the workpad.
+- The PR is up to date with the latest branch changes.
+- No actionable PR comments remain unresolved.
+- The workpad includes concise handoff notes, including commit SHA and validation summary.

--- a/docs/PERFORMANCE_READINESS.md
+++ b/docs/PERFORMANCE_READINESS.md
@@ -1,0 +1,64 @@
+# Performance Readiness
+
+Boxento should support thousands of saved widgets without mounting, polling, and saving all of them at once.
+
+## Benchmark Command
+
+Run the production dashboard benchmark:
+
+```bash
+bun run perf:dashboard
+```
+
+Useful variants:
+
+```bash
+bun run perf:dashboard -- --counts=100,500,1000
+bun run perf:dashboard -- --counts=1000 --add-widget=false
+bun run perf:dashboard -- --base-url=http://127.0.0.1:5173/
+```
+
+The benchmark seeds browser storage, loads the dashboard, waits for the grid to become usable, measures DOM/memory, and optionally adds one Notes widget through the real UI.
+
+## Current Baseline
+
+Measured on the production build after introducing deferred offscreen mounting, a shared visibility observer, CSS offscreen containment, append placement, and changed-config-only saves:
+
+| Saved widgets | Ready | Add widget | DOM nodes | Mounted widgets | Storage reads/writes on add |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 100 | 488 ms | 115 ms | 811 | 20 | 1 / 3 |
+| 500 | 503 ms | 101 ms | 2,411 | 20 | 1 / 3 |
+| 1,000 | 614 ms | 228 ms | 4,411 | 20 | 1 / 3 |
+| 2,000 | 765 ms | 383 ms | 8,411 | 20 | 1 / 3 |
+
+The 1,000-widget target is now met. At 2,000 widgets, add latency is much better but still above the 300 ms target, mostly because the dashboard still renders every grid wrapper.
+
+## Targets
+
+- 1,000 saved widgets become usable in under 2 seconds.
+- Adding one widget to a 1,000-widget dashboard completes in under 300 ms.
+- Widget selector with 5,000 available widgets opens in under 200 ms and searches in under 100 ms.
+- Only visible or recently used widgets are mounted; target 50-150 mounted widgets.
+- No storage or layout operation blocks the main thread for more than 100 ms.
+- API widgets use a shared refresh scheduler with endpoint dedupe and no more than 25 concurrent requests.
+
+## Next Performance Ceiling
+
+The next meaningful step is grid virtualization or paging at the dashboard-item layer. Deferred mounting stops widget internals from loading, but `react-grid-layout` still owns every wrapper, so add and layout work still grows with saved widget count.
+
+## Widget And Layout Audit Checks
+
+- Performance work must preserve existing widget visuals. Do not add new hover effects, shadows, borders, transitions, or visual treatments unless the change directly fixes clipping, overflow, or a broken recovery path.
+- Compact and one-column widgets must not show clipped headers like `Weat...`; hide the standard header when the title and controls cannot fit.
+- Wide and 4K-class viewports must use the available dashboard canvas and the matching wide breakpoint instead of capping the grid at laptop width.
+- Existing authored wide layouts should be preserved; missing wide layouts can be derived from the closest saved smaller breakpoint.
+
+## PM-Ready Acceptance Criteria
+
+- Users can save thousands of widgets without the dashboard becoming slow to open.
+- Adding a widget remains fast on large dashboards.
+- Unseen offscreen widgets do not refresh API data until they are visible or explicitly opened.
+- The widget picker remains searchable when the catalog grows to thousands of entries.
+- Dashboard saves update only changed records instead of rewriting every widget.
+- Narrow widget states do not expose clipped titles or overlapping controls.
+- 4K users see a dashboard that uses the extra screen width.

--- a/docs/WIDGET_DEVELOPMENT.md
+++ b/docs/WIDGET_DEVELOPMENT.md
@@ -320,14 +320,20 @@ All widgets MUST use a consistent structure and styling:
 
 ### 2. Responsive Design
 
-Widgets must be responsive to different sizes, with a minimum size of 2x2:
+Widgets must be responsive to different sizes. A widget can support `1x1` only when it has a deliberate tiny state and is listed in `TINY_READY_WIDGET_TYPES`; otherwise use the registry minimums that match the real UX:
 
+- **1x1**: Glanceable icon, metric, or setup tap target
 - **2x2**: Default view with essential information
 - **Wide (e.g., 4x2)**: Horizontal layout with expanded information
 - **Tall (e.g., 2x4)**: Vertical layout with expanded information
 - **Large (e.g., 4x4, 6x6)**: Full view with detailed information
 
-Note: Widgets cannot be smaller than 2x2 as this is enforced by the application.
+#### Header Fit
+
+- Do not ship clipped widget headers such as `Weat...` in narrow columns, tiny states, or short rows.
+- If the standard header cannot show the title and controls cleanly, hide the outer header and expose settings through a size-appropriate overlay or in-widget control.
+- Audit `1x1`, one-column tall, short-row, default, and large/app states before marking a widget tiny-ready or reducing its minimum size.
+- Keep header actions minimal and never let settings, titles, resize handles, or primary content overlap.
 
 ### 3. Theme Support
 
@@ -441,6 +447,7 @@ When working with external APIs:
 - **Progressive enhancement**: Display more information as widget size increases, prioritizing the most important content in smaller sizes.
 - **Adaptive content display**: Truncate and format content based on widget size to maintain readability.
 - **Responsive typography**: Adjust font sizes based on widget size when necessary.
+- **External displays**: Verify dashboards on wide/4K-class viewports. Widgets should use the active wide breakpoint instead of assuming a centered laptop-width canvas.
 
 ### State and Lifecycle
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,6 +8,7 @@
       "name": "boxento-functions",
       "version": "1.0.0",
       "dependencies": {
+        "@google-cloud/functions-framework": "^5.0.2",
         "@mozilla/readability": "^0.6.0",
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^5.0.0",
@@ -62,6 +63,29 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -334,6 +358,328 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@google-cloud/functions-framework": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-framework/-/functions-framework-5.0.2.tgz",
+      "integrity": "sha512-QDPRkPO1KWqbJ+z5RexKjZzHilIK5vM58YFkr/GZU5NIBcCb7Vd4dBKn9cLxEMaBxg6bXbmqEhF6O6977gLNkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/express": "^5.0.0",
+        "body-parser": "^2.2.2",
+        "cloudevents": "^10.0.0",
+        "express": "^5.0.0",
+        "minimist": "^1.2.8",
+        "on-finished": "^2.3.0",
+        "read-package-up": "^11.0.0"
+      },
+      "bin": {
+        "functions-framework": "build/src/main.js",
+        "functions-framework-nodejs": "build/src/main.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@google-cloud/functions-framework/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@google-cloud/paginator": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
@@ -600,7 +946,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -691,6 +1036,12 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
@@ -777,6 +1128,39 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -836,6 +1220,21 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -871,7 +1270,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -913,6 +1311,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -957,6 +1373,32 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cloudevents": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-10.0.0.tgz",
+      "integrity": "sha512-uyzC+PpMMRawbouHO+3mlisr3QfEDObmo2pN4oTTF6dZncZgpIzdasZx0tRBFI1dMsqCLZZXMtz8cUuvYqHdbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "json-bigint": "^1.0.0",
+        "process": "^0.11.10",
+        "util": "^0.12.4",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=20 <=24"
+      }
+    },
+    "node_modules/cloudevents/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/color-convert": {
@@ -1100,6 +1542,23 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1357,8 +1816,23 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.1.3",
@@ -1425,6 +1899,18 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/firebase-admin": {
@@ -1497,6 +1983,21 @@
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
         "@types/serve-static": "*"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -1595,6 +2096,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-caller-file": {
@@ -1736,6 +2246,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1753,7 +2275,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -1775,6 +2296,24 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
@@ -1915,6 +2454,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1930,6 +2481,34 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1940,11 +2519,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "license": "MIT"
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -1959,6 +2581,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jose": {
       "version": "4.15.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
@@ -1967,6 +2604,12 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "28.1.0",
@@ -2013,10 +2656,15 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -2279,6 +2927,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2349,6 +3006,20 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2397,7 +3068,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2413,6 +3083,23 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2460,6 +3147,30 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
@@ -2559,6 +3270,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2618,6 +3365,55 @@
         "node": ">=14"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2637,6 +3433,23 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2725,6 +3538,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2811,6 +3641,38 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "license": "CC0-1.0"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
@@ -3057,6 +3919,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3099,6 +3973,18 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -3106,6 +3992,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -3135,6 +4034,16 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {
@@ -3213,6 +4122,27 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -3235,8 +4165,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,6 +16,7 @@
     "node": "20"
   },
   "dependencies": {
+    "@google-cloud/functions-framework": "^5.0.2",
     "@mozilla/readability": "^0.6.0",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "bunx vitest",
     "test:e2e": "node scripts/run-playwright.mjs",
     "test:e2e:reuse": "PLAYWRIGHT_USE_EXISTING_SERVER=1 node scripts/run-playwright.mjs",
+    "perf:dashboard": "node scripts/benchmark-dashboard-performance.mjs",
     "preview": "bunx --bun vite preview",
     "deploy": "bun run build && firebase deploy --only hosting"
   },

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,5 +1,12 @@
 # What's New
 
+## May 22, 2026
+
+### 🐛 Bug Fixes
+• Widget API Errors: Replaced raw JSON parser failures like `Unexpected token '<'` with clear messages when an API endpoint returns HTML, empty content, or invalid JSON.
+• Monitoring Widgets: Uptime Kuma and Healthchecks now keep retry, settings, and delete controls available when their backend endpoint fails.
+• Docker/Self-hosted UX: Better diagnostics for misrouted backend proxies, login pages, or frontend app shells returned from widget API calls.
+
 ## December 27, 2025
 
 ### 🚀 Multi-Dashboard & Sharing
@@ -120,4 +127,4 @@
   - Flight Tracker
   - Geography Quiz
   - GitHub Streak
-  - Pomodoro Timer 
+  - Pomodoro Timer

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,6 +1,5 @@
-const CACHE_NAME = 'boxento-cache-v1';
-const urlsToCache = [
-  '/',
+const CACHE_NAME = 'boxento-cache-v2';
+const STATIC_URLS = [
   '/index.html',
   '/favicon.ico',
   '/favicon.svg',
@@ -10,59 +9,101 @@ const urlsToCache = [
   '/icons/icon-512x512.png'
 ];
 
+const STATIC_URL_SET = new Set(STATIC_URLS);
+
 self.addEventListener('install', (event) => {
+  self.skipWaiting();
+
   event.waitUntil(
     caches.open(CACHE_NAME)
       .then((cache) => {
-        return cache.addAll(urlsToCache);
+        return cache.addAll(STATIC_URLS);
       })
   );
 });
 
-self.addEventListener('fetch', (event) => {
-  event.respondWith(
-    caches.match(event.request)
-      .then((response) => {
-        // Cache hit - return the response from the cached version
-        if (response) {
-          return response;
-        }
-        
-        // Not in cache - fetch and cache the result
-        return fetch(event.request).then(
-          (response) => {
-            // Check if we received a valid response
-            if (!response || response.status !== 200 || response.type !== 'basic') {
-              return response;
-            }
-
-            // Clone the response as it's a stream that can only be consumed once
-            const responseToCache = response.clone();
-
-            caches.open(CACHE_NAME)
-              .then((cache) => {
-                cache.put(event.request, responseToCache);
-              });
-
-            return response;
-          }
-        );
-      })
-  );
-});
-
-// Clean up old caches
 self.addEventListener('activate', (event) => {
-  const cacheWhitelist = [CACHE_NAME];
   event.waitUntil(
-    caches.keys().then((cacheNames) => {
-      return Promise.all(
+    caches.keys()
+      .then((cacheNames) => Promise.all(
         cacheNames.map((cacheName) => {
-          if (cacheWhitelist.indexOf(cacheName) === -1) {
+          if (cacheName !== CACHE_NAME) {
             return caches.delete(cacheName);
           }
+
+          return undefined;
         })
-      );
-    })
+      ))
+      .then(() => self.clients.claim())
   );
-}); 
+});
+
+const fetchAndUpdateCache = async (request) => {
+  const response = await fetch(request);
+
+  if (response && response.status === 200 && response.type === 'basic') {
+    const cache = await caches.open(CACHE_NAME);
+    await cache.put(request, response.clone());
+  }
+
+  return response;
+};
+
+const networkFirst = async (request, fallbackUrl) => {
+  try {
+    return await fetchAndUpdateCache(request);
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    if (fallbackUrl) {
+      const fallbackResponse = await caches.match(fallbackUrl);
+      if (fallbackResponse) {
+        return fallbackResponse;
+      }
+    }
+
+    throw error;
+  }
+};
+
+const cacheFirst = async (request) => {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) {
+    return cachedResponse;
+  }
+
+  return fetchAndUpdateCache(request);
+};
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  if (request.method !== 'GET') {
+    return;
+  }
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirst(request, '/index.html'));
+    return;
+  }
+
+  if (url.pathname.startsWith('/assets/')) {
+    event.respondWith(networkFirst(request));
+    return;
+  }
+
+  if (STATIC_URL_SET.has(url.pathname)) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  event.respondWith(fetch(request));
+});

--- a/scripts/benchmark-dashboard-performance.mjs
+++ b/scripts/benchmark-dashboard-performance.mjs
@@ -1,0 +1,356 @@
+import { spawn } from 'node:child_process';
+import { existsSync, rmSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { chromium } from 'playwright';
+
+const BREAKPOINTS = ['xxxl', 'xxl', 'xl', 'lg', 'md', 'sm', 'xs', 'xxs'];
+const COLS = {
+  xxxl: 24,
+  xxl: 18,
+  xl: 14,
+  lg: 12,
+  md: 10,
+  sm: 6,
+  xs: 4,
+  xxs: 2,
+};
+
+const args = Object.fromEntries(
+  process.argv.slice(2).map((arg) => {
+    const [key, value = 'true'] = arg.replace(/^--/, '').split('=');
+    return [key, value];
+  })
+);
+
+const counts = (args.counts || '100,500,1000,2000')
+  .split(',')
+  .map((value) => Number(value.trim()))
+  .filter((value) => Number.isInteger(value) && value > 0);
+const widgetType = args.widget || 'notes';
+const shouldBuild = args.build !== 'false' && !args['base-url'];
+const shouldMeasureAdd = args['add-widget'] !== 'false';
+const viewportWidth = Number(args.width || 1440);
+const viewportHeight = Number(args.height || 900);
+
+const formatMs = (value) => value === null || value === undefined ? '-' : `${Math.round(value)}ms`;
+const formatMb = (bytes) => bytes === null || bytes === undefined ? '-' : `${Math.round(bytes / 1024 / 1024)}MB`;
+const formatKb = (bytes) => `${Math.round(bytes / 1024)}KB`;
+
+function run(command, commandArgs, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      stdio: options.stdio || 'inherit',
+      env: { ...process.env, ...options.env },
+      shell: process.platform === 'win32',
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${commandArgs.join(' ')} exited with ${code}`));
+      }
+    });
+  });
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+async function waitForUrl(url, timeoutMs = 30_000) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep polling until the preview server is ready.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+function createLayouts(count) {
+  const layouts = {};
+
+  for (const breakpoint of BREAKPOINTS) {
+    const columnCount = COLS[breakpoint];
+    const isMobile = breakpoint === 'xs' || breakpoint === 'xxs';
+    const width = isMobile ? 2 : 3;
+    const height = isMobile ? 2 : 3;
+    const perRow = Math.max(1, Math.floor(columnCount / width));
+
+    layouts[breakpoint] = Array.from({ length: count }, (_, index) => ({
+      i: `${widgetType}-${index}`,
+      x: (index % perRow) * width,
+      y: Math.floor(index / perRow) * height,
+      w: width,
+      h: height,
+      minW: 1,
+      minH: 1,
+    }));
+  }
+
+  return layouts;
+}
+
+function createWidgets(count) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `${widgetType}-${index}`,
+    type: widgetType,
+    config: {
+      title: `Benchmark ${index}`,
+      content: 'Benchmark fixture',
+    },
+  }));
+}
+
+async function seedDashboard(page, count) {
+  const widgets = createWidgets(count);
+  const layouts = createLayouts(count);
+  const storageBytes = Buffer.byteLength(JSON.stringify({ widgets, layouts }));
+
+  await page.evaluate(({ seededWidgets, seededLayouts }) => {
+    localStorage.clear();
+    localStorage.setItem('theme', 'light');
+    localStorage.setItem('boxento-current-dashboard', 'personal');
+    localStorage.setItem('boxento-dashboards', JSON.stringify([
+      {
+        id: 'personal',
+        name: 'Personal',
+        visibility: 'private',
+        sharedWith: [],
+        isDefault: true,
+        createdAt: '2026-05-22T00:00:00.000Z',
+      },
+    ]));
+    localStorage.setItem('boxento-widgets-personal', JSON.stringify(seededWidgets));
+    localStorage.setItem('boxento-layouts-personal', JSON.stringify(seededLayouts));
+    localStorage.setItem('boxento-widgets', JSON.stringify(seededWidgets));
+    localStorage.setItem('boxento-layouts', JSON.stringify(seededLayouts));
+    localStorage.setItem('boxento-widget-configs', JSON.stringify({}));
+  }, {
+    seededWidgets: widgets,
+    seededLayouts: layouts,
+  });
+
+  return storageBytes;
+}
+
+async function waitForDashboardReady(page, count) {
+  await page.waitForFunction((expectedCount) => {
+    const appWidgets = document.querySelectorAll('.app-widget').length;
+    const layoutLoading = Boolean(document.querySelector('.layout-loading'));
+    return appWidgets === expectedCount && !layoutLoading;
+  }, count, { timeout: 90_000 });
+}
+
+async function collectStats(page) {
+  return page.evaluate(() => ({
+    nodeCount: document.getElementsByTagName('*').length,
+    appWidgetCount: document.querySelectorAll('.app-widget').length,
+    widgetContainerCount: document.querySelectorAll('.widget-container').length,
+    deferredPlaceholderCount: document.querySelectorAll('[data-deferred-widget-placeholder]').length,
+    gridItemCount: document.querySelectorAll('.react-grid-item').length,
+    heapBytes: performance.memory ? performance.memory.usedJSHeapSize : null,
+  }));
+}
+
+async function measureAddWidget(page, expectedCount) {
+  await page.evaluate(() => {
+    window.__boxentoStorageStats = { get: 0, set: 0, bytes: 0 };
+    const originalGetItem = Storage.prototype.getItem;
+    const originalSetItem = Storage.prototype.setItem;
+    Storage.prototype.getItem = function getItemWithStats(key) {
+      window.__boxentoStorageStats.get += 1;
+      return originalGetItem.call(this, key);
+    };
+    Storage.prototype.setItem = function setItemWithStats(key, value) {
+      window.__boxentoStorageStats.set += 1;
+      window.__boxentoStorageStats.bytes += String(value).length;
+      return originalSetItem.call(this, key, value);
+    };
+  });
+
+  const start = performance.now();
+  await page.getByRole('button', { name: 'Add widget' }).click();
+  await page.getByRole('button', { name: 'Add Notes widget' }).click();
+  await page.waitForFunction((count) => document.querySelectorAll('.app-widget').length === count, expectedCount, {
+    timeout: 90_000,
+  });
+  const addWidgetMs = performance.now() - start;
+
+  const storageStats = await page.evaluate(() => window.__boxentoStorageStats);
+  return { addWidgetMs, storageStats };
+}
+
+function findChromeExecutable() {
+  if (process.env.PLAYWRIGHT_EXECUTABLE_PATH) {
+    return process.env.PLAYWRIGHT_EXECUTABLE_PATH;
+  }
+
+  const candidates = process.platform === 'darwin'
+    ? [
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+      ]
+    : [
+        '/usr/bin/google-chrome',
+        '/usr/bin/google-chrome-stable',
+        '/usr/bin/chromium',
+        '/usr/bin/chromium-browser',
+        '/usr/bin/microsoft-edge',
+      ];
+
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+async function launchBrowser() {
+  const executablePath = findChromeExecutable();
+
+  try {
+    return await chromium.launch({
+      headless: true,
+      ...(executablePath ? { executablePath } : {}),
+      args: ['--disable-extensions', '--no-first-run'],
+    });
+  } catch (error) {
+    throw new Error([
+      'Unable to launch Chromium for the benchmark.',
+      executablePath ? `Tried executable: ${executablePath}` : 'No system Chrome/Chromium executable was found.',
+      'Install Playwright browsers with: npx playwright install chromium',
+      `Original error: ${error instanceof Error ? error.message : String(error)}`,
+    ].join('\n'));
+  }
+}
+
+function printResults(results) {
+  console.log('\nDashboard performance results');
+  console.log(`Widget type: ${widgetType}`);
+  console.table(results.map((result) => ({
+    widgets: result.count,
+    storage: formatKb(result.storageBytes),
+    ready: formatMs(result.readyMs),
+    add: formatMs(result.addWidgetMs),
+    nodes: result.nodeCount,
+    mounted: result.widgetContainerCount,
+    deferred: result.deferredPlaceholderCount,
+    heap: formatMb(result.heapBytes),
+    storageGets: result.storageStats?.get ?? '-',
+    storageSets: result.storageStats?.set ?? '-',
+  })));
+  console.log('\nTargets: 1,000 saved widgets usable <2s; add widget <300ms; no single storage/layout task >100ms.');
+}
+
+async function main() {
+  if (!counts.length) {
+    throw new Error('Provide at least one positive count, for example --counts=100,500,1000');
+  }
+
+  let baseUrl = args['base-url'];
+  let previewProcess;
+  let outputDir;
+
+  if (!baseUrl) {
+    outputDir = path.join(await mkdtemp(path.join(tmpdir(), 'boxento-dashboard-perf-')), 'dist');
+
+    if (shouldBuild) {
+      await run('bunx', ['--bun', 'vite', 'build', '--outDir', outputDir, '--emptyOutDir']);
+    }
+
+    const port = Number(args.port || await getFreePort());
+    baseUrl = `http://127.0.0.1:${port}/`;
+    previewProcess = spawn('bunx', [
+      '--bun',
+      'vite',
+      'preview',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(port),
+      '--strictPort',
+      '--outDir',
+      outputDir,
+    ], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: process.platform === 'win32',
+    });
+
+    await waitForUrl(baseUrl);
+  }
+
+  const browser = await launchBrowser();
+  const page = await browser.newPage({
+    viewport: {
+      width: viewportWidth,
+      height: viewportHeight,
+    },
+  });
+  page.setDefaultTimeout(90_000);
+
+  const results = [];
+
+  for (const count of counts) {
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded' });
+    const storageBytes = await seedDashboard(page, count);
+    const start = performance.now();
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForDashboardReady(page, count);
+    const readyMs = performance.now() - start;
+    await page.waitForTimeout(250);
+    const stats = await collectStats(page);
+    const addStats = shouldMeasureAdd
+      ? await measureAddWidget(page, count + 1)
+      : { addWidgetMs: null, storageStats: null };
+
+    results.push({
+      count,
+      storageBytes,
+      readyMs,
+      addWidgetMs: addStats.addWidgetMs,
+      storageStats: addStats.storageStats,
+      ...stats,
+    });
+  }
+
+  await browser.close();
+
+  if (previewProcess) {
+    previewProcess.kill();
+  }
+
+  if (outputDir && args.keep !== 'true') {
+    rmSync(path.dirname(outputDir), { recursive: true, force: true });
+  }
+
+  printResults(results);
+
+  if (args.json) {
+    console.log(JSON.stringify(results, null, 2));
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,8 @@ import {
 } from '@/lib/dashboardViewport'
 import { getWidgetGridDimensions } from '@/lib/widgetGridDimensions'
 import { useNetworkStatus } from '@/lib/useNetworkStatus'
+import { getConfigWidgetIdsToSave } from '@/lib/widgetConfigPersistence'
+import type { WidgetConfigPersistenceOptions } from '@/lib/widgetConfigPersistence'
 import { AppFooter } from '@/components/AppFooter'
 import { useStorage } from '@/lib/storage/StorageContext'
 import { getStorageProvider } from '@/lib/storage'
@@ -103,9 +105,8 @@ const cloneLayoutsByBreakpoint = (sourceLayouts: LayoutsByBreakpoint): LayoutsBy
   )
 );
 
-type SaveWidgetsOptions = {
+type SaveWidgetsOptions = WidgetConfigPersistenceOptions & {
   debounce?: boolean;
-  configWidgetIdsToSave?: Iterable<string>;
 };
 
 const createAppendLayoutItem = (
@@ -660,15 +661,14 @@ function App() {
    * Save widgets to storage using the current storage provider
    *
    * @param updatedWidgets - Array of widgets to save
-   * @param debounce - If true, save is scheduled for 500ms later and function returns immediately.
-   *                   If false, waits for save to complete before returning.
+   * @param options - Save timing and widget config persistence options.
    */
   const saveWidgets = async (
     updatedWidgets: Widget[],
-    options: boolean | SaveWidgetsOptions = true
+    options: boolean | SaveWidgetsOptions = { debounce: true }
   ): Promise<void> => {
     const saveOptions: SaveWidgetsOptions = typeof options === 'boolean'
-      ? { debounce: options }
+      ? { debounce: options, persistAllConfigs: true }
       : options;
     const debounce = saveOptions.debounce ?? true;
     widgetsRef.current = updatedWidgets;
@@ -677,11 +677,12 @@ function App() {
     const provider = getStorageProvider();
 
     const widgetsById = new Map(updatedWidgets.map(widget => [widget.id, widget]));
-    const configWidgetIdsToSave = Array.from(saveOptions.configWidgetIdsToSave ?? []);
+    const configWidgetIdsToSave = getConfigWidgetIdsToSave(updatedWidgets, saveOptions);
 
-    // Persist only configs that changed. Re-saving every widget config made a
-    // single add scale linearly with dashboard size.
-    void Promise.all(configWidgetIdsToSave.map((widgetId) => {
+    // Most saves persist only configs that changed. Legacy immediate saves can
+    // still persist all configs for migration paths where widget metadata and
+    // config documents must both be written.
+    const configSavePromise = Promise.all(configWidgetIdsToSave.map((widgetId) => {
       const widget = widgetsById.get(widgetId);
       if (widget?.config && widget.id) {
         const configToSave = prepareWidgetConfigForSave(widget.config);
@@ -689,6 +690,12 @@ function App() {
       }
       return Promise.resolve();
     }));
+
+    if (debounce) {
+      void configSavePromise;
+    } else {
+      await configSavePromise;
+    }
 
     // Save widgets to storage provider
     const saveToProvider = async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ import { Changelog } from '@/components/Changelog'
 import { faviconService } from '@/lib/services/favicon'
 import { useAppSettings } from '@/context/AppSettingsContext'
 import { DashboardContextMenu } from '@/components/dashboard/DashboardContextMenu'
-import DashboardWidgetFrame from '@/components/dashboard/DashboardWidgetFrame'
+import DeferredDashboardWidgetFrame from '@/components/dashboard/DeferredDashboardWidgetFrame'
 import { DashboardSwitcher, Dashboard, DashboardVisibility } from '@/components/dashboard/DashboardSwitcher'
 import {
   createDashboardRecord,
@@ -56,7 +56,6 @@ import {
   validateLayouts,
 } from '@/lib/dashboardLayouts'
 import {
-  DASHBOARD_LAYOUT_MAX_WIDTH,
   calculateDashboardRowHeight,
   getDashboardBreakpointForWidth,
 } from '@/lib/dashboardViewport'
@@ -104,23 +103,72 @@ const cloneLayoutsByBreakpoint = (sourceLayouts: LayoutsByBreakpoint): LayoutsBy
   )
 );
 
+type SaveWidgetsOptions = {
+  debounce?: boolean;
+  configWidgetIdsToSave?: Iterable<string>;
+};
+
+const createAppendLayoutItem = (
+  widgetId: string,
+  colCount: number,
+  breakpoint: string,
+  existingLayout: LayoutItem[] = []
+): LayoutItem => {
+  const isMobile = breakpoint === 'xs' || breakpoint === 'xxs';
+  const width = isMobile ? 2 : Math.min(3, colCount);
+  const height = isMobile ? 2 : 3;
+  const y = existingLayout.reduce((bottom, item) => Math.max(bottom, item.y + item.h), 0);
+
+  return {
+    i: widgetId,
+    x: 0,
+    y,
+    w: width,
+    h: height,
+    minW: 2,
+    minH: 2,
+    ...(isMobile ? { maxW: 2, maxH: 2 } : {}),
+  };
+};
+
 function App() {
   // Get storage context for provider info
   const { providerType: _providerType, refresh: refreshStorage, isInitialized: storageInitialized } = useStorage();
 
   // Register service worker for PWA functionality
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/service-worker.js')
-          .then(() => {
-            // ServiceWorker registration successful
-          })
-          .catch(error => {
-            console.error('ServiceWorker registration failed: ', error);
-          });
-      });
+    if (!('serviceWorker' in navigator)) {
+      return undefined;
     }
+
+    if (!import.meta.env.PROD) {
+      void navigator.serviceWorker.getRegistrations()
+        .then((registrations) => Promise.all(registrations.map((registration) => registration.unregister())))
+        .catch((error) => {
+          console.error('ServiceWorker cleanup failed: ', error);
+        });
+
+      if ('caches' in window) {
+        void caches.keys()
+          .then((cacheNames) => Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName))))
+          .catch((error) => {
+            console.error('Cache cleanup failed: ', error);
+          });
+      }
+
+      return undefined;
+    }
+
+    const registerServiceWorker = () => {
+      navigator.serviceWorker.register('/service-worker.js')
+        .then((registration) => registration.update())
+        .catch(error => {
+          console.error('ServiceWorker registration failed: ', error);
+        });
+    };
+
+    window.addEventListener('load', registerServiceWorker);
+    return () => window.removeEventListener('load', registerServiceWorker);
   }, []);
 
   // Track online status for PWA functionality with toast notifications
@@ -351,11 +399,12 @@ function App() {
   ): { layouts: LayoutsByBreakpoint; changed: boolean } => {
     const widgetIds = new Set(widgetsToReconcile.map((widget) => widget.id));
     const widgetsById = new Map(widgetsToReconcile.map((widget) => [widget.id, widget]));
+    const validatedInputLayouts = validateLayouts(layoutsToReconcile, options);
     const reconciledLayouts: LayoutsByBreakpoint = {};
     let changed = false;
 
     BREAKPOINT_ORDER.forEach((breakpoint) => {
-      const currentLayout = layoutsToReconcile[breakpoint] || [];
+      const currentLayout = validatedInputLayouts[breakpoint] || [];
       const filteredLayout = currentLayout.filter((item) => widgetIds.has(item.i));
 
       if (filteredLayout.length !== currentLayout.length) {
@@ -614,19 +663,32 @@ function App() {
    * @param debounce - If true, save is scheduled for 500ms later and function returns immediately.
    *                   If false, waits for save to complete before returning.
    */
-  const saveWidgets = async (updatedWidgets: Widget[], debounce = true): Promise<void> => {
+  const saveWidgets = async (
+    updatedWidgets: Widget[],
+    options: boolean | SaveWidgetsOptions = true
+  ): Promise<void> => {
+    const saveOptions: SaveWidgetsOptions = typeof options === 'boolean'
+      ? { debounce: options }
+      : options;
+    const debounce = saveOptions.debounce ?? true;
     widgetsRef.current = updatedWidgets;
     setWidgets(updatedWidgets);
 
     const provider = getStorageProvider();
 
-    // Save each widget's configuration separately using configManager
-    updatedWidgets.forEach(widget => {
-      if (widget.config && widget.id) {
+    const widgetsById = new Map(updatedWidgets.map(widget => [widget.id, widget]));
+    const configWidgetIdsToSave = Array.from(saveOptions.configWidgetIdsToSave ?? []);
+
+    // Persist only configs that changed. Re-saving every widget config made a
+    // single add scale linearly with dashboard size.
+    void Promise.all(configWidgetIdsToSave.map((widgetId) => {
+      const widget = widgetsById.get(widgetId);
+      if (widget?.config && widget.id) {
         const configToSave = prepareWidgetConfigForSave(widget.config);
-        configManager.saveWidgetConfig(widget.id, configToSave);
+        return configManager.saveWidgetConfig(widget.id, configToSave);
       }
-    });
+      return Promise.resolve();
+    }));
 
     // Save widgets to storage provider
     const saveToProvider = async () => {
@@ -855,11 +917,10 @@ function App() {
       // Calculate column count for this breakpoint
       const colCount = cols[breakpoint as keyof typeof cols];
       
-      // Create default layout item based on the breakpoint
-      // Pass existing layout so it can find the first available position
-      const defaultItem = createDefaultLayoutItem(
+      // Adding one widget should not rescan thousands of existing layout cells.
+      // Auto-arrange remains available when the user wants to fill gaps.
+      const defaultItem = createAppendLayoutItem(
         widgetId,
-        updatedLayouts[breakpoint].length,
         colCount,
         breakpoint,
         updatedLayouts[breakpoint]
@@ -879,13 +940,11 @@ function App() {
       );
     });
     
-    // Update states and save data
-    setWidgets(updatedWidgets);
-    setLayouts(updatedLayouts);
+    // Update state through the save helpers to avoid duplicate dashboard renders.
     setLastCreatedWidgetId(widgetId);
     
     // Save changes
-    saveWidgets(updatedWidgets);
+    saveWidgets(updatedWidgets, { configWidgetIdsToSave: [widgetId] });
     saveLayouts(updatedLayouts, false);
     
     // Close the widget selector if it's open
@@ -1028,7 +1087,7 @@ function App() {
           data-breakpoint={currentBreakpoint}
           style={isMobileViewport ? { marginBottom: '16px', height: 'auto' } : undefined}
         >
-          <DashboardWidgetFrame
+          <DeferredDashboardWidgetFrame
             widget={widget}
             width={width}
             height={height}
@@ -1050,7 +1109,7 @@ function App() {
             key={widget.id} 
             className="mobile-widget-item"
           >
-            <DashboardWidgetFrame
+            <DeferredDashboardWidgetFrame
               widget={widget}
               width={2}
               height={2}
@@ -1538,12 +1597,12 @@ function App() {
           // Calculate column count for this breakpoint
           const colCount = cols[breakpoint as keyof typeof cols];
           
-          // Create default layout item based on the breakpoint
-          const defaultItem = createDefaultLayoutItem(
+          // Append pasted widgets cheaply; auto-arrange can fill gaps later.
+          const defaultItem = createAppendLayoutItem(
             widgetId, 
-            updatedLayouts[breakpoint].length, 
             colCount,
-            breakpoint
+            breakpoint,
+            updatedLayouts[breakpoint]
           );
           
           // Set appropriate size for video content
@@ -1555,13 +1614,11 @@ function App() {
           updatedLayouts[breakpoint].push(defaultItem);
         });
         
-        // Update states
-        setWidgets(updatedWidgets);
-        setLayouts(updatedLayouts);
+        // Update state through the save helpers to avoid duplicate dashboard renders.
         setLastCreatedWidgetId(widgetId);
         
         // Save changes
-        saveWidgets(updatedWidgets);
+        saveWidgets(updatedWidgets, { configWidgetIdsToSave: [widgetId] });
         saveLayouts(updatedLayouts, false);
         break;
         
@@ -1760,7 +1817,7 @@ function App() {
               </div>
             ) : (
               <div className="desktop-view-container">
-                <div style={{ width: '100%', maxWidth: DASHBOARD_LAYOUT_MAX_WIDTH, margin: '0 auto' }}>
+                <div className="dashboard-canvas">
                   {!isLayoutReady && widgets.length > 0 && (
                     <div className="px-[10px] py-[10px]">
                       <div className="grid grid-cols-2 md:grid-cols-6 lg:grid-cols-12 gap-4 auto-rows-[100px]">
@@ -1813,8 +1870,6 @@ function App() {
                         transformScale={1}
                         style={{
                           width: '100%',
-                          maxWidth: DASHBOARD_LAYOUT_MAX_WIDTH,
-                          margin: '0 auto',
                           minHeight: '100%',
                         }}
                       >

--- a/src/components/dashboard/DashboardWidgetFrame.tsx
+++ b/src/components/dashboard/DashboardWidgetFrame.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, useMemo } from 'react';
-import { Loader2 } from 'lucide-react';
+import React, { Suspense, useCallback, useMemo } from 'react';
+import { AlertTriangle, Loader2, RefreshCcw, Trash2 } from 'lucide-react';
 
 import { getWidgetComponent } from '@/components/widgets';
 import WidgetErrorBoundary from '@/components/widgets/common/WidgetErrorBoundary';
@@ -20,6 +20,67 @@ type DashboardWidgetFrameProps = DashboardWidgetFrameComparisonProps & {
 const DashboardWidgetLoadingFallback = () => (
   <div className="flex h-full w-full items-center justify-center rounded-lg bg-card">
     <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+  </div>
+);
+
+const isDynamicImportError = (error: Error): boolean => (
+  /dynamically imported module|importing a module script failed|chunkloaderror|loading chunk/i.test(error.message)
+);
+
+type DashboardWidgetErrorFallbackProps = {
+  isReadOnly: boolean;
+  message: string;
+  onDelete: () => void;
+  showReload?: boolean;
+};
+
+const DashboardWidgetErrorFallback: React.FC<DashboardWidgetErrorFallbackProps> = ({
+  isReadOnly,
+  message,
+  onDelete,
+  showReload = false,
+}) => (
+  <div
+    className="widget-drag-handle flex h-full w-full flex-col items-center justify-center rounded-lg bg-red-50 p-4 text-red-800 dark:bg-red-900 dark:bg-opacity-20 dark:text-red-200"
+    data-testid="widget-error-fallback"
+  >
+    <AlertTriangle className="mb-2" size={24} aria-hidden="true" />
+    <h3 className="mb-1 text-sm font-medium">Widget Error</h3>
+    <p className="text-center text-xs">
+      <span className="break-all">
+        {message}
+      </span>
+    </p>
+
+    <div className="mt-3 flex flex-wrap justify-center gap-2">
+      {showReload ? (
+        <button
+          type="button"
+          className="text-xs underline"
+          onClick={(event) => {
+            event.stopPropagation();
+            window.location.reload();
+          }}
+        >
+          <RefreshCcw className="size-4" aria-hidden="true" />
+          Reload
+        </button>
+      ) : null}
+
+      {!isReadOnly ? (
+        <button
+          type="button"
+          className="text-xs underline"
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 className="size-4" aria-hidden="true" />
+          Remove widget
+        </button>
+      ) : null}
+    </div>
   </div>
 );
 
@@ -46,12 +107,17 @@ const DashboardWidgetFrameComponent: React.FC<DashboardWidgetFrameProps> = ({
       },
     }),
   }), [isReadOnly, onDeleteWidget, onUpdateWidgetConfig, widget]);
+  const handleDeleteWidget = useCallback(() => {
+    void onDeleteWidget(widget.id);
+  }, [onDeleteWidget, widget.id]);
 
   if (!WidgetComponent) {
     return (
-      <div className="widget-error">
-        <p>Widget type "{widget.type}" not found</p>
-      </div>
+      <DashboardWidgetErrorFallback
+        isReadOnly={isReadOnly}
+        message={`Widget type "${widget.type}" is not available.`}
+        onDelete={handleDeleteWidget}
+      />
     );
   }
 
@@ -63,7 +129,17 @@ const DashboardWidgetFrameComponent: React.FC<DashboardWidgetFrameProps> = ({
       onClick={stopDashboardInteractionPropagation}
       onContextMenu={stopDashboardContextMenuPropagation}
     >
-      <WidgetErrorBoundary>
+      <WidgetErrorBoundary
+        resetKey={`${widget.id}:${widget.type}`}
+        fallback={(error) => (
+          <DashboardWidgetErrorFallback
+            isReadOnly={isReadOnly}
+            message={error.message || 'An error occurred while rendering this widget.'}
+            onDelete={handleDeleteWidget}
+            showReload={isDynamicImportError(error)}
+          />
+        )}
+      >
         <Suspense fallback={<DashboardWidgetLoadingFallback />}>
           <WidgetComponent
             width={width}

--- a/src/components/dashboard/DeferredDashboardWidgetFrame.tsx
+++ b/src/components/dashboard/DeferredDashboardWidgetFrame.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import DashboardWidgetFrame from '@/components/dashboard/DashboardWidgetFrame';
+
+type DeferredDashboardWidgetFrameProps = React.ComponentProps<typeof DashboardWidgetFrame> & {
+  defer?: boolean;
+  rootMargin?: string;
+};
+
+type DeferredFrameObserver = {
+  callbacks: Map<Element, () => void>;
+  observer: IntersectionObserver;
+};
+
+const deferredFrameObservers = new Map<string, DeferredFrameObserver>();
+
+const observeDeferredFrame = (
+  element: Element,
+  rootMargin: string,
+  onIntersect: () => void
+) => {
+  let sharedObserver = deferredFrameObservers.get(rootMargin);
+
+  if (!sharedObserver) {
+    const callbacks = new Map<Element, () => void>();
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+
+        const callback = callbacks.get(entry.target);
+        if (!callback) {
+          return;
+        }
+
+        callbacks.delete(entry.target);
+        observer.unobserve(entry.target);
+        callback();
+      });
+    }, {
+      root: null,
+      rootMargin,
+      threshold: 0,
+    });
+
+    sharedObserver = { callbacks, observer };
+    deferredFrameObservers.set(rootMargin, sharedObserver);
+  }
+
+  sharedObserver.callbacks.set(element, onIntersect);
+  sharedObserver.observer.observe(element);
+
+  return () => {
+    sharedObserver.callbacks.delete(element);
+    sharedObserver.observer.unobserve(element);
+  };
+};
+
+export function DeferredDashboardWidgetFrame({
+  defer = true,
+  rootMargin = '900px 0px',
+  ...props
+}: DeferredDashboardWidgetFrameProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [shouldMount, setShouldMount] = useState(!defer);
+
+  useEffect(() => {
+    if (!defer || shouldMount) {
+      return;
+    }
+
+    const element = containerRef.current;
+    if (!element || typeof IntersectionObserver === 'undefined') {
+      setShouldMount(true);
+      return;
+    }
+
+    return observeDeferredFrame(element, rootMargin, () => {
+      setShouldMount(true);
+    });
+  }, [defer, rootMargin, shouldMount]);
+
+  return (
+    <div ref={containerRef} className="h-full">
+      {shouldMount ? (
+        <DashboardWidgetFrame {...props} />
+      ) : (
+        <div
+          aria-hidden="true"
+          className="h-full w-full rounded-lg bg-card/60"
+          data-deferred-widget-placeholder
+        />
+      )}
+    </div>
+  );
+}
+
+export default DeferredDashboardWidgetFrame;

--- a/src/components/dashboard/DeferredDashboardWidgetFrame.tsx
+++ b/src/components/dashboard/DeferredDashboardWidgetFrame.tsx
@@ -10,6 +10,7 @@ type DeferredDashboardWidgetFrameProps = React.ComponentProps<typeof DashboardWi
 type DeferredFrameObserver = {
   callbacks: Map<Element, () => void>;
   observer: IntersectionObserver;
+  refCount: number;
 };
 
 const deferredFrameObservers = new Map<string, DeferredFrameObserver>();
@@ -44,16 +45,30 @@ const observeDeferredFrame = (
       threshold: 0,
     });
 
-    sharedObserver = { callbacks, observer };
+    sharedObserver = { callbacks, observer, refCount: 0 };
     deferredFrameObservers.set(rootMargin, sharedObserver);
   }
 
+  sharedObserver.refCount += 1;
   sharedObserver.callbacks.set(element, onIntersect);
   sharedObserver.observer.observe(element);
 
+  let disposed = false;
+
   return () => {
+    if (disposed) {
+      return;
+    }
+
+    disposed = true;
     sharedObserver.callbacks.delete(element);
     sharedObserver.observer.unobserve(element);
+    sharedObserver.refCount -= 1;
+
+    if (sharedObserver.refCount === 0) {
+      sharedObserver.observer.disconnect();
+      deferredFrameObservers.delete(rootMargin);
+    }
   };
 };
 

--- a/src/components/dashboard/SharedDashboardView.tsx
+++ b/src/components/dashboard/SharedDashboardView.tsx
@@ -7,7 +7,6 @@ import { getWidgetComponent } from '@/components/widgets';
 import WidgetErrorBoundary from '@/components/widgets/common/WidgetErrorBoundary';
 import { breakpoints, cols } from '@/lib/layoutUtils';
 import {
-  DASHBOARD_LAYOUT_MAX_WIDTH,
   calculateDashboardRowHeight,
   getDashboardBreakpointForWidth,
 } from '@/lib/dashboardViewport';
@@ -219,7 +218,7 @@ export function SharedDashboardView() {
 
       {/* Dashboard content */}
       <main className="flex-1 pt-16 md:pt-20">
-        <div style={{ width: '100%', maxWidth: DASHBOARD_LAYOUT_MAX_WIDTH, margin: '0 auto' }}>
+        <div className="dashboard-canvas">
           <ResponsiveGridLayout
             className="layout"
             layouts={dashboard.layouts}
@@ -235,8 +234,6 @@ export function SharedDashboardView() {
             compactType="vertical"
             style={{
               width: '100%',
-              maxWidth: DASHBOARD_LAYOUT_MAX_WIDTH,
-              margin: '0 auto',
             }}
           >
             {dashboard.widgets.map((widget) => (

--- a/src/components/widgets/CronHealthWidget/index.tsx
+++ b/src/components/widgets/CronHealthWidget/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
+import { parseJsonResponseText } from '@/lib/jsonResponseGuard';
 import WidgetHeader from '../common/WidgetHeader';
 import { WidgetProps } from '@/types';
 import { CronHealthWidgetConfig, Job, HealthResponse } from './types';
@@ -73,7 +74,8 @@ const CronHealthWidget: React.FC<CronHealthWidgetProps> = ({ width, height, conf
       setError(null);
       const response = await fetch(localConfig.apiUrl);
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data: HealthResponse = await response.json();
+      const body = await response.text();
+      const data = parseJsonResponseText<HealthResponse>(body, response);
       setHealthData(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch');

--- a/src/components/widgets/FlightTrackerWidget/index.tsx
+++ b/src/components/widgets/FlightTrackerWidget/index.tsx
@@ -390,6 +390,15 @@ const FlightTrackerWidget: React.FC<FlightTrackerWidgetProps> = ({
   // --- Setup prompt when no flights configured ---
   const renderSetup = () => {
     if (setupState === 'checking') {
+      if (isCompact) {
+        return (
+          <div className="flex-1 flex flex-col items-center justify-center gap-2 px-2 text-center text-muted-foreground">
+            <RefreshCw className="h-6 w-6 animate-spin" />
+            <p className="text-xs">Checking flight setup</p>
+          </div>
+        );
+      }
+
       return (
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
           <RefreshCw className="h-8 w-8 animate-spin" />
@@ -399,6 +408,39 @@ const FlightTrackerWidget: React.FC<FlightTrackerWidgetProps> = ({
     }
 
     if (setupBlocked) {
+      if (isCompact) {
+        const isSetupError = setupState === 'error';
+
+        return (
+          <div className="flex-1 flex flex-col items-center justify-center gap-2 px-2 text-center">
+            {isSetupError ? (
+              <AlertCircle className="h-6 w-6 text-muted-foreground" />
+            ) : (
+              <Plane className="h-6 w-6 text-muted-foreground" />
+            )}
+            <p className="text-xs font-medium leading-tight text-foreground">
+              {isSetupError ? 'Couldn\u2019t verify flight setup' : 'Flight data setup needed'}
+            </p>
+            {!readOnly && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => {
+                  if (isSetupError) {
+                    void checkFlightTrackerSetup();
+                  } else {
+                    setShowSettings(true);
+                  }
+                }}
+              >
+                {isSetupError ? 'Retry' : 'Setup'}
+              </Button>
+            )}
+          </div>
+        );
+      }
+
       if (setupState === 'error') {
         return (
           <div className="flex-1 flex flex-col items-center justify-center gap-3 px-4 text-center">
@@ -465,6 +507,27 @@ const FlightTrackerWidget: React.FC<FlightTrackerWidgetProps> = ({
                 Recheck Setup
               </Button>
             </div>
+          )}
+        </div>
+      );
+    }
+
+    if (isCompact) {
+      return (
+        <div className="flex-1 flex flex-col items-center justify-center gap-2 px-2 text-center">
+          <Plane className="h-6 w-6 text-muted-foreground" />
+          <p className="text-xs font-medium leading-tight text-foreground">
+            No flights tracked yet
+          </p>
+          {!readOnly && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              onClick={() => setShowSettings(true)}
+            >
+              Add Flight
+            </Button>
           )}
         </div>
       );

--- a/src/components/widgets/HealthchecksWidget/index.tsx
+++ b/src/components/widgets/HealthchecksWidget/index.tsx
@@ -11,7 +11,6 @@ import {
   Timer,
   XCircle,
 } from 'lucide-react';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
@@ -25,6 +24,7 @@ import {
 } from '../../ui/select';
 import { Skeleton } from '../../ui/skeleton';
 import WidgetHeader from '../common/WidgetHeader';
+import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../common/WidgetSettingsDialog';
 import { cn } from '@/lib/utils';
 import {
   formatMonitoringItemLimitPlaceholder,
@@ -32,6 +32,7 @@ import {
   getMonitoringItemLimit,
   parseMonitoringItemLimit,
 } from '../common/monitoringItemLimit';
+import { readMonitoringJson } from '../common/monitoringApiResponse';
 import { HealthchecksCheck, HealthchecksStatus, HealthchecksWidgetConfig, HealthchecksWidgetData } from './types';
 
 const SQLITE_API_URL = import.meta.env.VITE_SQLITE_API_URL || '';
@@ -181,11 +182,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
           : undefined,
         signal: AbortSignal.timeout(10000),
       });
-      if (!response.ok) {
-        const payload = await response.json().catch(() => null);
-        throw new Error(payload?.error || `HTTP ${response.status}`);
-      }
-      const payload: HealthchecksWidgetData = await response.json();
+      const payload = await readMonitoringJson<HealthchecksWidgetData>(response, 'Healthchecks');
       setData(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch');
@@ -304,13 +301,64 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  const renderError = () => (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-sm text-muted-foreground">
-      <XCircle className="h-5 w-5 text-red-500" />
-      <span>{error}</span>
-      <Button variant="secondary" size="sm" onClick={fetchData}>Retry</Button>
-    </div>
-  );
+  const renderError = () => {
+    if (isTiny) {
+      const tinyError = (
+        <>
+          <XCircle className="h-5 w-5 text-red-500" />
+          <span className="text-[10px] font-medium text-muted-foreground">Error</span>
+        </>
+      );
+
+      if (readOnly) {
+        return (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+            {tinyError}
+          </div>
+        );
+      }
+
+      return (
+        <button
+          type="button"
+          className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md text-center"
+          onClick={() => setShowSettings(true)}
+          aria-label="Open Healthchecks settings"
+        >
+          {tinyError}
+        </button>
+      );
+    }
+
+    const compactError = isCompact && !isShort;
+
+    return (
+      <div className={cn(
+        'flex h-full flex-col items-center justify-center text-center text-muted-foreground',
+        compactError ? 'gap-1.5 p-2 text-xs' : 'gap-2 p-3 text-sm',
+      )}>
+        <XCircle className="h-5 w-5 text-red-500" />
+        <span className={cn('max-w-full break-words', compactError && 'line-clamp-2')}>
+          {error}
+        </span>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            className={cn(compactError && 'h-7 px-2 text-xs')}
+            onClick={fetchData}
+          >
+            Retry
+          </Button>
+          {!compactError && !readOnly && (
+            <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>
+              Settings
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   const renderEmpty = (message: string) => (
     <div className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-sm text-muted-foreground">
@@ -584,14 +632,6 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  if (loading && !data) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderLoading()}</div>;
-  }
-
-  if (error && !data && !shouldShowSetupPrompt) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderError()}</div>;
-  }
-
   return (
     <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>
       {!isTiny && !isApp && (
@@ -603,7 +643,9 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
       )}
 
       <div className={cn('flex-1 overflow-hidden', isTiny ? 'p-1' : isApp ? '' : 'p-2 md:p-3')}>
-        {shouldShowSetupPrompt ? renderSetupPrompt()
+        {loading && !data ? renderLoading()
+          : error && !data && !shouldShowSetupPrompt ? renderError()
+          : shouldShowSetupPrompt ? renderSetupPrompt()
           : isTiny ? renderTiny()
           : isShort ? renderShort()
           : isApp ? renderApp()
@@ -612,13 +654,22 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
           : renderDefault()}
       </div>
 
-      <Dialog open={showSettings} onOpenChange={setShowSettings}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{localConfig.title || DEFAULT_CONFIG.title} Settings</DialogTitle>
-          </DialogHeader>
-          <div className="max-h-[min(60vh,500px)] overflow-y-auto py-2">
-            <div className="space-y-4 px-1">
+      <WidgetSettingsDialog
+        open={showSettings}
+        onOpenChange={setShowSettings}
+        title={`${localConfig.title || DEFAULT_CONFIG.title} Settings`}
+        description="Configure the Healthchecks instance, API key, and backend endpoint."
+        bodyClassName="py-2"
+        footer={(
+          <WidgetSettingsDialogFooter
+            onDelete={config?.onDelete}
+            deleteLabel="Delete Widget"
+            onCancel={() => setShowSettings(false)}
+            onSave={saveSettings}
+          />
+        )}
+      >
+        <div className="space-y-4 px-1">
               <div className="space-y-2">
                 <Label htmlFor="health-title">Title</Label>
                 <Input
@@ -747,20 +798,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
                 />
               </div>
             </div>
-          </div>
-          <DialogFooter>
-            <div className="flex w-full justify-between">
-              {config?.onDelete ? (
-                <Button variant="destructive" onClick={config.onDelete}>Delete Widget</Button>
-              ) : <div />}
-              <div className="ml-auto flex items-center gap-2">
-                <Button variant="outline" onClick={() => setShowSettings(false)}>Cancel</Button>
-                <Button onClick={saveSettings}>Save</Button>
-              </div>
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      </WidgetSettingsDialog>
     </div>
   );
 };

--- a/src/components/widgets/JellyfinWidget/index.tsx
+++ b/src/components/widgets/JellyfinWidget/index.tsx
@@ -300,17 +300,42 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
 
   // --- Needs config view ---
 
-  const renderNeedsConfig = () => (
-    <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-      <Settings className="h-8 w-8" />
-      <p className="text-sm">Configure Jellyfin to get started</p>
-      {!readOnly && (
-        <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>
-          Open Settings
-        </Button>
-      )}
-    </div>
-  );
+  const renderNeedsConfig = () => {
+    if (isTiny) {
+      const setupIcon = <Settings className="h-5 w-5 text-muted-foreground" />;
+
+      if (readOnly) {
+        return (
+          <div className="flex flex-1 items-center justify-center">
+            {setupIcon}
+          </div>
+        );
+      }
+
+      return (
+        <button
+          type="button"
+          className="flex flex-1 items-center justify-center rounded-md"
+          onClick={() => setShowSettings(true)}
+          aria-label="Open Jellyfin settings"
+        >
+          {setupIcon}
+        </button>
+      );
+    }
+
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
+        <Settings className="h-8 w-8" />
+        <p className="text-sm">Configure Jellyfin to get started</p>
+        {!readOnly && (
+          <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>
+            Open Settings
+          </Button>
+        )}
+      </div>
+    );
+  };
 
   // --- Loading / Error states ---
 

--- a/src/components/widgets/KumaWidget/index.tsx
+++ b/src/components/widgets/KumaWidget/index.tsx
@@ -8,7 +8,6 @@ import {
   Settings,
   XCircle,
 } from 'lucide-react';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '../../ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
@@ -22,6 +21,7 @@ import {
 } from '../../ui/select';
 import { Skeleton } from '../../ui/skeleton';
 import WidgetHeader from '../common/WidgetHeader';
+import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../common/WidgetSettingsDialog';
 import { cn } from '@/lib/utils';
 import {
   formatMonitoringItemLimitPlaceholder,
@@ -29,6 +29,7 @@ import {
   getMonitoringItemLimit,
   parseMonitoringItemLimit,
 } from '../common/monitoringItemLimit';
+import { readMonitoringJson } from '../common/monitoringApiResponse';
 import { KumaMonitor, KumaMonitorStatus, KumaWidgetConfig, KumaWidgetData } from './types';
 
 const SQLITE_API_URL = import.meta.env.VITE_SQLITE_API_URL || '';
@@ -168,11 +169,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
           : undefined,
         signal: AbortSignal.timeout(10000),
       });
-      if (!response.ok) {
-        const payload = await response.json().catch(() => null);
-        throw new Error(payload?.error || `HTTP ${response.status}`);
-      }
-      const payload: KumaWidgetData = await response.json();
+      const payload = await readMonitoringJson<KumaWidgetData>(response, 'Uptime Kuma');
       setData(payload);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch');
@@ -290,13 +287,64 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  const renderError = () => (
-    <div className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center text-sm text-muted-foreground">
-      <XCircle className="h-5 w-5 text-red-500" />
-      <span>{error}</span>
-      <Button variant="secondary" size="sm" onClick={fetchData}>Retry</Button>
-    </div>
-  );
+  const renderError = () => {
+    if (isTiny) {
+      const tinyError = (
+        <>
+          <XCircle className="h-5 w-5 text-red-500" />
+          <span className="text-[10px] font-medium text-muted-foreground">Error</span>
+        </>
+      );
+
+      if (readOnly) {
+        return (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
+            {tinyError}
+          </div>
+        );
+      }
+
+      return (
+        <button
+          type="button"
+          className="flex h-full w-full flex-col items-center justify-center gap-1 rounded-md text-center"
+          onClick={() => setShowSettings(true)}
+          aria-label="Open Uptime Kuma settings"
+        >
+          {tinyError}
+        </button>
+      );
+    }
+
+    const compactError = isCompact && !isShort;
+
+    return (
+      <div className={cn(
+        'flex h-full flex-col items-center justify-center text-center text-muted-foreground',
+        compactError ? 'gap-1.5 p-2 text-xs' : 'gap-2 p-3 text-sm',
+      )}>
+        <XCircle className="h-5 w-5 text-red-500" />
+        <span className={cn('max-w-full break-words', compactError && 'line-clamp-2')}>
+          {error}
+        </span>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            className={cn(compactError && 'h-7 px-2 text-xs')}
+            onClick={fetchData}
+          >
+            Retry
+          </Button>
+          {!compactError && !readOnly && (
+            <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>
+              Settings
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  };
 
   const renderEmpty = (message: string) => (
     <div className="flex h-full flex-col items-center justify-center gap-2 px-3 text-center text-sm text-muted-foreground">
@@ -564,14 +612,6 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
     </div>
   );
 
-  if (loading && !data) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderLoading()}</div>;
-  }
-
-  if (error && !data && !shouldShowSetupPrompt) {
-    return <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>{renderError()}</div>;
-  }
-
   return (
     <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : '')}>
       {!isTiny && !isApp && (
@@ -583,7 +623,9 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
       )}
 
       <div className={cn('flex-1 overflow-hidden', isTiny ? 'p-1' : isApp ? '' : 'p-2 md:p-3')}>
-        {shouldShowSetupPrompt ? renderSetupPrompt()
+        {loading && !data ? renderLoading()
+          : error && !data && !shouldShowSetupPrompt ? renderError()
+          : shouldShowSetupPrompt ? renderSetupPrompt()
           : isTiny ? renderTiny()
           : isShort ? renderShort()
           : isApp ? renderApp()
@@ -592,13 +634,22 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
           : renderDefault()}
       </div>
 
-      <Dialog open={showSettings} onOpenChange={setShowSettings}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{localConfig.title || DEFAULT_CONFIG.title} Settings</DialogTitle>
-          </DialogHeader>
-          <div className="max-h-[min(60vh,500px)] overflow-y-auto py-2">
-            <div className="space-y-4 px-1">
+      <WidgetSettingsDialog
+        open={showSettings}
+        onOpenChange={setShowSettings}
+        title={`${localConfig.title || DEFAULT_CONFIG.title} Settings`}
+        description="Configure the Uptime Kuma status page and backend endpoint."
+        bodyClassName="py-2"
+        footer={(
+          <WidgetSettingsDialogFooter
+            onDelete={config?.onDelete}
+            deleteLabel="Delete Widget"
+            onCancel={() => setShowSettings(false)}
+            onSave={saveSettings}
+          />
+        )}
+      >
+        <div className="space-y-4 px-1">
               <div className="space-y-2">
                 <Label htmlFor="kuma-title">Title</Label>
                 <Input
@@ -714,20 +765,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
                 />
               </div>
             </div>
-          </div>
-          <DialogFooter>
-            <div className="flex w-full justify-between">
-              {config?.onDelete ? (
-                <Button variant="destructive" onClick={config.onDelete}>Delete Widget</Button>
-              ) : <div />}
-              <div className="ml-auto flex items-center gap-2">
-                <Button variant="outline" onClick={() => setShowSettings(false)}>Cancel</Button>
-                <Button onClick={saveSettings}>Save</Button>
-              </div>
-            </div>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      </WidgetSettingsDialog>
     </div>
   );
 };

--- a/src/components/widgets/PomodoroWidget/index.tsx
+++ b/src/components/widgets/PomodoroWidget/index.tsx
@@ -13,6 +13,7 @@ import { Label } from '../../ui/label';
 import { Input } from '../../ui/input';
 import { Button } from '../../ui/button';
 import { faviconService } from '@/lib/services/favicon';
+import { cn } from '@/lib/utils';
 
 /**
  * Pomodoro Widget Component
@@ -615,52 +616,61 @@ const PomodoroWidget: React.FC<PomodoroWidgetProps> = ({ width, height, config }
 
   // Large view (4x4 or larger)
   const renderLargeView = () => {
+    const isTightLarge = height <= 4;
+
     return (
-      <div className="flex flex-col items-center justify-center h-full space-y-6">
-        <div className={`text-6xl font-bold ${getModeColor()}`}>
+      <div className={cn(
+        'flex h-full min-h-0 flex-col items-center justify-center overflow-hidden',
+        isTightLarge ? 'gap-3' : 'gap-6',
+      )}>
+        <div className={`${isTightLarge ? 'text-5xl' : 'text-6xl'} font-bold leading-none ${getModeColor()}`}>
           {formatTime(timeLeft)}
         </div>
-        <div className="text-xl font-medium">{getModeLabel()}</div>
-        <div className="text-md opacity-75 text-center max-w-[280px]">{getModeDescription()}</div>
+        <div className={cn('font-medium', isTightLarge ? 'text-lg' : 'text-xl')}>
+          {getModeLabel()}
+        </div>
+        <div className={cn('text-center opacity-75', isTightLarge ? 'max-w-[220px] text-sm' : 'max-w-[280px] text-md')}>
+          {getModeDescription()}
+        </div>
         {!readOnly && (
-          <div className="flex space-x-4 mt-4">
+          <div className={cn('flex', isTightLarge ? 'gap-3' : 'mt-4 gap-4')}>
             <Button
               variant="secondary"
               size="icon"
-              className="rounded-full h-14 w-14"
+              className={cn('rounded-full', isTightLarge ? 'h-12 w-12' : 'h-14 w-14')}
               onClick={toggleTimer}
               aria-label={isActive ? 'Pause' : 'Start'}
             >
-              {isActive ? <Pause size={24} /> : <Play size={24} />}
+              {isActive ? <Pause size={isTightLarge ? 20 : 24} /> : <Play size={isTightLarge ? 20 : 24} />}
             </Button>
             <Button
               variant="secondary"
               size="icon"
-              className="rounded-full h-14 w-14"
+              className={cn('rounded-full', isTightLarge ? 'h-12 w-12' : 'h-14 w-14')}
               onClick={resetTimer}
               aria-label="Reset"
             >
-              <RotateCcw size={24} />
+              <RotateCcw size={isTightLarge ? 20 : 24} />
             </Button>
           </div>
         )}
-        <div className="text-lg mt-2">
+        <div className={cn(isTightLarge ? 'text-sm' : 'mt-2 text-lg')}>
           Cycle: {cyclesCompleted % (localConfig.cyclesBeforeLongBreak || 4) || (localConfig.cyclesBeforeLongBreak || 4)}/{localConfig.cyclesBeforeLongBreak || 4}
         </div>
-        <div className="text-md opacity-75">
+        <div className={cn('opacity-75', isTightLarge ? 'text-sm' : 'text-md')}>
           Total completed: {cyclesCompleted}
         </div>
-        <div className="grid grid-cols-3 gap-4 mt-4 text-center w-full">
-          <div className="bg-muted p-3 rounded-lg">
-            <div className="text-sm opacity-75">Focus Time</div>
+        <div className={cn('grid w-full grid-cols-3 text-center', isTightLarge ? 'gap-2' : 'mt-4 gap-4')}>
+          <div className={cn('rounded-lg bg-muted', isTightLarge ? 'p-2' : 'p-3')}>
+            <div className={cn('opacity-75', isTightLarge ? 'text-xs' : 'text-sm')}>Focus Time</div>
             <div className="font-medium">{localConfig.workDuration} min</div>
           </div>
-          <div className="bg-muted p-3 rounded-lg">
-            <div className="text-sm opacity-75">Short Break</div>
+          <div className={cn('rounded-lg bg-muted', isTightLarge ? 'p-2' : 'p-3')}>
+            <div className={cn('opacity-75', isTightLarge ? 'text-xs' : 'text-sm')}>Short Break</div>
             <div className="font-medium">{localConfig.breakDuration} min</div>
           </div>
-          <div className="bg-muted p-3 rounded-lg">
-            <div className="text-sm opacity-75">Long Break</div>
+          <div className={cn('rounded-lg bg-muted', isTightLarge ? 'p-2' : 'p-3')}>
+            <div className={cn('opacity-75', isTightLarge ? 'text-xs' : 'text-sm')}>Long Break</div>
             <div className="font-medium">{localConfig.longBreakDuration} min</div>
           </div>
         </div>

--- a/src/components/widgets/QRCodeWidget/index.tsx
+++ b/src/components/widgets/QRCodeWidget/index.tsx
@@ -636,7 +636,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
                       value={localConfig.errorLevel || 'M'}
                       onValueChange={(value) => updateConfig({ errorLevel: value as 'L' | 'M' | 'Q' | 'H' })}
                     >
-                      <SelectTrigger className="h-7 w-[100px] text-xs">
+                      <SelectTrigger className="h-7 w-[9.5rem] text-xs">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>

--- a/src/components/widgets/ReaderWidget/index.tsx
+++ b/src/components/widgets/ReaderWidget/index.tsx
@@ -330,9 +330,24 @@ const ReaderWidget: React.FC<ReaderWidgetProps> = ({ width, height, config }) =>
   const renderTiny = () => {
     const stateView = renderStateOrNull();
     if (stateView) {
+      const stateIcon = <BookMarked size={18} className="text-muted-foreground" />;
+
+      if (!localConfig.apiToken && !readOnly) {
+        return (
+          <button
+            type="button"
+            className="flex flex-1 items-center justify-center rounded-md"
+            onClick={openSettings}
+            aria-label="Open Reader settings"
+          >
+            {stateIcon}
+          </button>
+        );
+      }
+
       return (
         <div className="flex-1 flex items-center justify-center">
-          <BookMarked size={18} className="text-muted-foreground" />
+          {stateIcon}
         </div>
       );
     }
@@ -965,11 +980,12 @@ const ReaderWidget: React.FC<ReaderWidgetProps> = ({ width, height, config }) =>
 
   return (
     <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : 'p-2 md:p-3')}>
-      <WidgetHeader
-        title={isTiny ? undefined : (localConfig.title || 'Reader')}
-        onSettingsClick={readOnly ? undefined : openSettings}
-        compact={isTiny}
-      />
+      {!isTiny && (
+        <WidgetHeader
+          title={localConfig.title || 'Reader'}
+          onSettingsClick={readOnly ? undefined : openSettings}
+        />
+      )}
 
       {/* Size-branching render (most specific first) */}
       {isTiny ? renderTiny()

--- a/src/components/widgets/ReadwiseWidget/index.tsx
+++ b/src/components/widgets/ReadwiseWidget/index.tsx
@@ -281,16 +281,24 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
   // --- Setup prompt (no API token) ---
   if (!localConfig.apiToken) {
     if (isTiny) {
+      const setupIcon = <BookOpen className="h-5 w-5 text-muted-foreground" />;
+
       return (
-        <div className="widget-container h-full flex flex-col widget-drag-handle p-1">
-          <WidgetHeader
-            title={undefined}
-            onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
-            compact
-          />
-          <div className="flex-1 flex items-center justify-center">
-            <BookOpen className="h-5 w-5 text-muted-foreground" />
-          </div>
+        <div className="widget-container flex h-full flex-col p-1 widget-drag-handle">
+          {readOnly ? (
+            <div className="flex flex-1 items-center justify-center">
+              {setupIcon}
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="flex flex-1 items-center justify-center rounded-md"
+              onClick={() => setShowSettings(true)}
+              aria-label="Open Readwise settings"
+            >
+              {setupIcon}
+            </button>
+          )}
           {renderSettingsDialog()}
         </div>
       );
@@ -959,11 +967,12 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
 
   return (
     <div className={cn('widget-container h-full flex flex-col', isTiny ? 'widget-drag-handle' : 'p-2 md:p-3')}>
-      <WidgetHeader
-        title={isTiny ? undefined : localConfig.title}
-        onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
-        compact={isTiny}
-      />
+      {!isTiny && (
+        <WidgetHeader
+          title={localConfig.title}
+          onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
+        />
+      )}
 
       {isTiny
         ? renderTiny()

--- a/src/components/widgets/WeatherWidget/index.tsx
+++ b/src/components/widgets/WeatherWidget/index.tsx
@@ -39,6 +39,7 @@ interface CitySearchResult {
  */
 const WeatherWidget: FC<WeatherWidgetProps> = ({ width, height, config, refreshInterval = 15 }) => {
   const isTiny = width === 1 && height === 1;
+  const isNarrowColumn = width === 1;
   const isShort = height === 1 && width > 1;
   const isApp = width >= 6 && height >= 6;
   const readOnly = config?.readOnly ?? false;
@@ -1306,9 +1307,9 @@ const WeatherWidget: FC<WeatherWidgetProps> = ({ width, height, config, refreshI
   return (
     <WidgetShell
       ref={widgetRef}
-      title="Weather"
+      title={isNarrowColumn ? undefined : 'Weather'}
       isTiny={isTiny}
-      hideHeader={isApp}
+      hideHeader={isApp || isNarrowColumn}
       compactHeader={isShort || width === 1 || height === 1}
       onSettingsClick={readOnly ? undefined : () => setIsSettingsOpen(true)}
       contentClassName={isTiny ? 'rounded-md p-2' : isApp ? '' : 'rounded-md'}

--- a/src/components/widgets/WorldClocksWidget/index.tsx
+++ b/src/components/widgets/WorldClocksWidget/index.tsx
@@ -813,14 +813,14 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
    */
   const renderMediumView = (): React.ReactElement => {
     return (
-      <div className="grid h-full grid-cols-2 overflow-y-auto p-2" style={{ gap: '0.55rem' }}>
+      <div className="grid h-full min-h-0 grid-cols-2 grid-rows-2 overflow-y-auto p-2" style={{ gap: '0.55rem' }}>
         {timezones.map(tz => {
           const display = getTimezoneDisplay(tz);
 
           return (
             <div
               key={tz.id}
-              className="flex flex-col items-center justify-between rounded-xl border border-border/60 bg-muted/35 px-2 py-2 text-center"
+              className="flex min-h-0 flex-col items-center justify-between overflow-hidden rounded-xl border border-border/60 bg-muted/35 px-2 py-2 text-center"
             >
               <div
                 className="min-h-[1.7rem] w-full px-1 font-semibold text-foreground"
@@ -936,15 +936,20 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
     // For 1-4 timezones, show larger clocks with more details
     if (timezones.length <= 4) {
+      const rows = Math.ceil(timezones.length / 2);
+
       return (
-        <div className="grid h-full grid-cols-2 transition-all duration-300" style={{ gap }}>
+        <div
+          className="grid h-full min-h-0 grid-cols-2 transition-all duration-300"
+          style={{ gap, gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))` }}
+        >
           {timezones.map(tz => {
             const display = getTimezoneDisplay(tz);
 
             return (
               <div
                 key={tz.id}
-                className="flex h-full flex-col items-center justify-between rounded-2xl border border-border/60 bg-muted/35 text-center transition-all duration-300"
+                className="flex min-h-0 flex-col items-center justify-between overflow-hidden rounded-2xl border border-border/60 bg-muted/35 text-center transition-all duration-300"
                 style={{ padding: cardPadding }}
               >
                 <div
@@ -1035,6 +1040,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
     const isDarkMode = document.documentElement.classList.contains('dark');
     const layoutScale = getAreaScale(16, 25);
     const columns = timezones.length <= 4 ? 2 : 3;
+    const rows = Math.ceil(timezones.length / columns);
     const clockSize = Math.round(interpolate(72, 84, layoutScale));
     const gap = `${interpolate(0.8, 1.1, layoutScale)}rem`;
     const cardPadding = `${interpolate(0.95, 1.2, layoutScale)}rem`;
@@ -1044,8 +1050,12 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
     return (
       <div
-        className="grid h-full overflow-y-auto transition-all duration-300"
-        style={{ gap, gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        className="grid h-full min-h-0 overflow-y-auto transition-all duration-300"
+        style={{
+          gap,
+          gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+          gridTemplateRows: timezones.length <= 6 ? `repeat(${rows}, minmax(0, 1fr))` : undefined,
+        }}
       >
         {timezones.map(tz => {
           const display = getTimezoneDisplay(tz);
@@ -1053,7 +1063,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
           return (
             <div
               key={tz.id}
-              className="flex h-full flex-col items-center justify-between rounded-2xl border border-border/60 bg-muted/35 text-center transition-all duration-300"
+              className="flex min-h-0 flex-col items-center justify-between overflow-hidden rounded-2xl border border-border/60 bg-muted/35 text-center transition-all duration-300"
               style={{ padding: cardPadding }}
             >
               <div

--- a/src/components/widgets/YearProgressWidget/index.tsx
+++ b/src/components/widgets/YearProgressWidget/index.tsx
@@ -290,7 +290,7 @@ const YearProgressWidget: React.FC<YearProgressProps> = React.memo(({ width, hei
     // For small widgets, use a more compact layout
     if (width <= 2) {
       return (
-        <div className="flex flex-col space-y-1 mt-1 px-0.5 text-xs font-medium">
+        <div className="mt-1 flex shrink-0 flex-col space-y-1 px-0.5 text-xs font-medium">
           {localConfig.showDaysLeft && (
             <div className="bg-muted px-2 py-0.5 rounded-full transition-colors duration-200 text-center">
               <span className="text-foreground font-semibold">{daysLeft}</span>
@@ -309,7 +309,7 @@ const YearProgressWidget: React.FC<YearProgressProps> = React.memo(({ width, hei
 
     // Standard layout for larger widgets
     return (
-      <div className="flex justify-between items-center mt-1.5 px-0.5 text-xs font-medium">
+      <div className="mt-1.5 flex shrink-0 items-center justify-between px-0.5 text-xs font-medium">
         {localConfig.showDaysLeft && (
           <div className="bg-muted px-2.5 py-1 rounded-full transition-colors duration-200">
             <span className="text-foreground font-semibold">{daysLeft}</span>
@@ -687,8 +687,8 @@ const YearProgressWidget: React.FC<YearProgressProps> = React.memo(({ width, hei
 
   // ─── Existing default view (dot grid + stats) ───────────────────────
   const renderDefaultView = useCallback(() => (
-    <div className="h-full flex flex-col justify-between">
-      <div ref={svgContainerRef} className="flex-grow flex items-center justify-center relative">
+    <div className="flex h-full min-h-0 flex-col justify-between">
+      <div ref={svgContainerRef} className="relative flex min-h-0 flex-1 items-center justify-center">
         <svg
           ref={svgRef}
           viewBox={gridLayout.viewBox}

--- a/src/components/widgets/common/WidgetErrorBoundary.tsx
+++ b/src/components/widgets/common/WidgetErrorBoundary.tsx
@@ -3,6 +3,8 @@ import { AlertTriangle } from 'lucide-react';
 
 interface WidgetErrorBoundaryProps {
   children: React.ReactNode;
+  fallback?: (error: Error) => React.ReactNode;
+  resetKey?: string;
 }
 
 interface WidgetErrorBoundaryState {
@@ -31,8 +33,18 @@ class WidgetErrorBoundary extends React.Component<WidgetErrorBoundaryProps, Widg
     console.error('Widget error:', error, errorInfo);
   }
 
+  componentDidUpdate(previousProps: WidgetErrorBoundaryProps): void {
+    if (previousProps.resetKey !== this.props.resetKey && this.state.hasError) {
+      this.setState({ hasError: false, error: null });
+    }
+  }
+
   render(): React.ReactNode {
     if (this.state.hasError) {
+      if (this.props.fallback && this.state.error) {
+        return this.props.fallback(this.state.error);
+      }
+
       return (
         <div className="w-full h-full flex flex-col items-center justify-center p-4 bg-red-50 dark:bg-red-900 dark:bg-opacity-20 text-red-800 dark:text-red-200 rounded-lg">
           <AlertTriangle className="mb-2" size={24} aria-hidden="true" />
@@ -48,4 +60,4 @@ class WidgetErrorBoundary extends React.Component<WidgetErrorBoundaryProps, Widg
   }
 }
 
-export default WidgetErrorBoundary; 
+export default WidgetErrorBoundary;

--- a/src/components/widgets/common/WidgetSelector.tsx
+++ b/src/components/widgets/common/WidgetSelector.tsx
@@ -29,6 +29,48 @@ const WidgetSelector = ({
 }: WidgetSelectorProps): React.ReactElement | null => {
   const [searchQuery, setSearchQuery] = useState<string>('');
 
+  const renderWidgetIcon = (icon?: string): React.ReactElement => {
+    switch (icon) {
+      case 'Calendar': return <Calendar className="size-4" />;
+      case 'Cloud': return <Cloud className="size-4" />;
+      case 'Clock': return <Clock className="size-4" />;
+      case 'Link': return <Link className="size-4" />;
+      case 'StickyNote': return <StickyNote className="size-4" />;
+      case 'CheckSquare': return <CheckSquare className="size-4" />;
+      case 'Timer': return <Timer className="size-4" />;
+      case 'DollarSign': return <DollarSign className="size-4" />;
+      case 'BookOpen': return <BookOpen className="size-4" />;
+      case 'Video': return <Video className="size-4" />;
+      case 'Rss': return <Rss className="size-4" />;
+      case 'Github': return <Github className="size-4" />;
+      case 'Plane': return <Plane className="size-4" />;
+      case 'Globe': return <Globe className="size-4" />;
+      default: return <Plus className="size-4" />;
+    }
+  };
+
+  const renderWidgetCard = (widget: WidgetConfig): React.ReactElement => (
+    <Button
+      key={widget.type}
+      type="button"
+      variant="ghost"
+      size="none"
+      className="h-auto w-full justify-start gap-3 border border-gray-100 bg-white p-4 text-left dark:border-[#2c2c2e] dark:bg-[#1c1c1e]"
+      onClick={() => onAddWidget(widget.type)}
+      aria-label={`Add ${widget.name} widget`}
+    >
+      <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-blue-100 text-blue-600 dark:bg-[#1c1c54] dark:text-blue-300">
+        {renderWidgetIcon(widget.icon)}
+      </span>
+      <span className="flex flex-1 flex-col pt-1 text-left">
+        <span className="text-sm text-gray-900 dark:text-[#f5f5f7]">{widget.name}</span>
+        {widget.description && (
+          <span className="mt-0.5 text-xs text-gray-500 dark:text-[#8e8e93]">{widget.description}</span>
+        )}
+      </span>
+    </Button>
+  );
+
   // Handle escape key press
   useEffect(() => {
     const handleEscapeKey = (event: KeyboardEvent) => {
@@ -94,44 +136,7 @@ const WidgetSelector = ({
             <h4 className="text-base font-semibold text-gray-700 dark:text-[#f5f5f7] mb-2">Search Results</h4>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
               {filteredWidgets.length > 0 ? (
-                filteredWidgets.map(widget => (
-                  <Button
-                    key={widget.type}
-                    type="button"
-                    variant="ghost"
-                    className="h-auto justify-start gap-3 border border-gray-100 bg-white p-4 text-left transition-all duration-200 hover:scale-[1.02] hover:bg-blue-50 hover:border-blue-200 hover:shadow-md dark:border-[#2c2c2e] dark:bg-[#1c1c1e] dark:hover:border-[#3c3c3e] dark:hover:bg-[#2c2c2e] dark:hover:shadow-black/20 dark:hover:shadow-lg"
-                    onClick={() => onAddWidget(widget.type)}
-                    aria-label={`Add ${widget.name} widget`}
-                  >
-                    <div className="flex items-center justify-center w-11 h-11 rounded-lg bg-blue-100 dark:bg-[#1c1c54] text-blue-600 dark:text-blue-300">
-                      {(() => {
-                        switch (widget.icon) {
-                          case 'Calendar': return <Calendar size={16} />;
-                          case 'Cloud': return <Cloud size={16} />;
-                          case 'Clock': return <Clock size={16} />;
-                          case 'Link': return <Link size={16} />;
-                          case 'StickyNote': return <StickyNote size={16} />;
-                          case 'CheckSquare': return <CheckSquare size={16} />;
-                          case 'Timer': return <Timer size={16} />;
-                          case 'DollarSign': return <DollarSign size={16} />;
-                          case 'BookOpen': return <BookOpen size={16} />;
-                          case 'Video': return <Video size={16} />;
-                          case 'Rss': return <Rss size={16} />;
-                          case 'Github': return <Github size={16} />;
-                          case 'Plane': return <Plane size={16} />;
-                          case 'Globe': return <Globe size={16} />;
-                          default: return <Plus size={16} />;
-                        }
-                      })()}
-                    </div>
-                    <div className="flex flex-col flex-1 pt-1">
-                      <div className="text-sm text-gray-900 dark:text-[#f5f5f7]">{widget.name}</div>
-                      {widget.description && (
-                        <div className="text-xs text-gray-500 dark:text-[#8e8e93] mt-0.5">{widget.description}</div>
-                      )}
-                    </div>
-                  </Button>
-                ))
+                filteredWidgets.map(renderWidgetCard)
               ) : (
                 <div className="col-span-full text-center py-8 text-gray-500 dark:text-[#8e8e93] text-sm">No widgets found matching "{searchQuery}"</div>
               )}
@@ -143,44 +148,7 @@ const WidgetSelector = ({
               <div key={category} className="mb-8">
                 <h4 className="text-base font-semibold text-gray-700 dark:text-[#f5f5f7] mb-2">{category}</h4>
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
-                  {widgets.map(widget => (
-                    <Button
-                      key={widget.type}
-                      type="button"
-                      variant="ghost"
-                      className="h-auto justify-start gap-3 border border-gray-100 bg-white p-4 text-left transition-all duration-200 hover:scale-[1.02] hover:bg-blue-50 hover:border-blue-200 hover:shadow-md dark:border-[#2c2c2e] dark:bg-[#1c1c1e] dark:hover:border-[#3c3c3e] dark:hover:bg-[#2c2c2e] dark:hover:shadow-black/20 dark:hover:shadow-lg"
-                      onClick={() => onAddWidget(widget.type)}
-                      aria-label={`Add ${widget.name} widget`}
-                    >
-                      <div className="flex items-center justify-center w-11 h-11 rounded-lg bg-blue-100 dark:bg-[#1c1c54] text-blue-600 dark:text-blue-300">
-                        {(() => {
-                          switch (widget.icon) {
-                            case 'Calendar': return <Calendar size={16} />;
-                            case 'Cloud': return <Cloud size={16} />;
-                            case 'Clock': return <Clock size={16} />;
-                            case 'Link': return <Link size={16} />;
-                            case 'StickyNote': return <StickyNote size={16} />;
-                            case 'CheckSquare': return <CheckSquare size={16} />;
-                            case 'Timer': return <Timer size={16} />;
-                            case 'DollarSign': return <DollarSign size={16} />;
-                            case 'BookOpen': return <BookOpen size={16} />;
-                            case 'Video': return <Video size={16} />;
-                            case 'Rss': return <Rss size={16} />;
-                            case 'Github': return <Github size={16} />;
-                            case 'Plane': return <Plane size={16} />;
-                            case 'Globe': return <Globe size={16} />;
-                            default: return <Plus size={16} />;
-                          }
-                        })()}
-                      </div>
-                      <div className="flex flex-col flex-1 pt-1 text-left">
-                        <div className="text-sm text-gray-900 dark:text-[#f5f5f7]">{widget.name}</div>
-                        {widget.description && (
-                          <div className="text-xs text-gray-500 dark:text-[#8e8e93] mt-0.5">{widget.description}</div>
-                        )}
-                      </div>
-                    </Button>
-                  ))}
+                  {widgets.map(renderWidgetCard)}
                 </div>
               </div>
             ))}

--- a/src/components/widgets/common/monitoringApiResponse.ts
+++ b/src/components/widgets/common/monitoringApiResponse.ts
@@ -1,0 +1,28 @@
+import { parseJsonResponseText } from '@/lib/jsonResponseGuard';
+
+const getPayloadMessage = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const record = payload as Record<string, unknown>;
+  const error = record.error;
+  const message = record.message;
+
+  if (typeof error === 'string' && error.trim()) return error;
+  if (typeof message === 'string' && message.trim()) return message;
+
+  return null;
+};
+
+export const readMonitoringJson = async <T>(
+  response: Response,
+  serviceName: string,
+): Promise<T> => {
+  const body = await response.text();
+  const payload = parseJsonResponseText<unknown>(body, response, `${serviceName} endpoint`);
+
+  if (!response.ok) {
+    throw new Error(getPayloadMessage(payload) || `HTTP ${response.status}`);
+  }
+
+  return payload as T;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -204,6 +204,16 @@
   @apply h-full w-full;
 }
 
+.react-grid-item.widget-wrapper.app-widget {
+  content-visibility: auto;
+  contain-intrinsic-size: 320px 240px;
+}
+
+.react-grid-item.widget-wrapper.app-widget.react-draggable-dragging,
+.react-grid-item.widget-wrapper.app-widget.resizing {
+  content-visibility: visible;
+}
+
 /* Mouse interaction states */
 .react-grid-item:active,
 .react-grid-item:focus,
@@ -445,7 +455,7 @@ body.react-grid-layout--resizing .react-grid-item:not(.resizing) {
 }
 
 .header-container {
-  @apply max-w-[1600px] mx-auto flex justify-between items-center px-3 sm:px-6 py-0;
+  @apply w-full flex justify-between items-center px-3 sm:px-6 py-0;
 }
 
 .header-left {
@@ -490,7 +500,11 @@ body.react-grid-layout--resizing .react-grid-item:not(.resizing) {
  */
 
 .dashboard-container {
-  @apply px-6 max-w-[1600px] mx-auto;
+  @apply w-full px-2 sm:px-3;
+}
+
+.dashboard-canvas {
+  width: 100%;
 }
 
 /* Empty dashboard call to action */

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,8 +23,6 @@ export const GRID = {
   MIN_WIDGET_WIDTH: 1,
   /** Default minimum widget height */
   MIN_WIDGET_HEIGHT: 1,
-  /** Keep desktop dashboards at a laptop-class canvas width on very large displays */
-  MAX_DESKTOP_LAYOUT_WIDTH: 1512,
   /** Container padding in pixels */
   CONTAINER_PADDING: 10,
   /** Margin between grid items in pixels */

--- a/src/lib/dashboardLayouts.ts
+++ b/src/lib/dashboardLayouts.ts
@@ -146,6 +146,18 @@ const findFallbackBreakpoint = (layouts: LayoutsByBreakpoint, breakpoint: Breakp
   return null;
 };
 
+const maybeRebalanceWideLayout = (
+  layout: LayoutItem[],
+  colCount: number,
+  options: ValidateLayoutsOptions
+): LayoutItem[] => {
+  if (!options.rebalanceWideSparse || colCount <= cols.lg) {
+    return layout;
+  }
+
+  return rebalanceWideSparseLayout(layout, colCount) ?? layout;
+};
+
 export const scaleLayoutToCols = (
   layout: LayoutItem[],
   fromCols: number,
@@ -289,14 +301,12 @@ export const validateLayouts = (
     const targetCols = cols[breakpoint];
     const fallbackCols = cols[fallbackBreakpoint];
 
-    // Preserve persisted wide-screen layouts as authored. Auto-scaling laptop layouts
-    // into wider breakpoints made the same dashboard drift on external displays.
-    if (targetCols > cols.lg) {
-      return;
-    }
-
     if (!currentLayout.length) {
-      validatedLayouts[breakpoint] = scaleLayoutToCols(fallbackLayout, fallbackCols, targetCols);
+      validatedLayouts[breakpoint] = maybeRebalanceWideLayout(
+        scaleLayoutToCols(fallbackLayout, fallbackCols, targetCols),
+        targetCols,
+        options
+      );
       return;
     }
 
@@ -305,14 +315,11 @@ export const validateLayouts = (
     }
 
     if (targetCols > cols.lg && layoutSignature(currentLayout) === layoutSignature(fallbackLayout)) {
-      validatedLayouts[breakpoint] = scaleLayoutToCols(fallbackLayout, fallbackCols, targetCols);
-    }
-
-    if (options.rebalanceWideSparse && targetCols > cols.lg) {
-      const rebalancedLayout = rebalanceWideSparseLayout(validatedLayouts[breakpoint], targetCols);
-      if (rebalancedLayout) {
-        validatedLayouts[breakpoint] = rebalancedLayout;
-      }
+      validatedLayouts[breakpoint] = maybeRebalanceWideLayout(
+        scaleLayoutToCols(fallbackLayout, fallbackCols, targetCols),
+        targetCols,
+        options
+      );
     }
   });
 

--- a/src/lib/dashboardViewport.ts
+++ b/src/lib/dashboardViewport.ts
@@ -6,21 +6,15 @@ export type DashboardViewportBreakpoint = keyof typeof cols;
 const DASHBOARD_BREAKPOINT_ORDER = Object.keys(breakpoints)
   .sort((a, b) => breakpoints[b as DashboardViewportBreakpoint] - breakpoints[a as DashboardViewportBreakpoint]) as DashboardViewportBreakpoint[];
 
-export const DASHBOARD_LAYOUT_MAX_WIDTH = GRID.MAX_DESKTOP_LAYOUT_WIDTH;
-
 export const getDashboardLayoutViewportWidth = (viewportWidth: number): number => {
-  if (viewportWidth < breakpoints.sm) {
-    return viewportWidth;
-  }
-
-  return Math.min(viewportWidth, DASHBOARD_LAYOUT_MAX_WIDTH);
+  return viewportWidth;
 };
 
 export const getDashboardBreakpointForWidth = (viewportWidth: number): DashboardViewportBreakpoint => {
-  const boundedWidth = getDashboardLayoutViewportWidth(viewportWidth);
+  const layoutWidth = getDashboardLayoutViewportWidth(viewportWidth);
 
   for (const breakpoint of DASHBOARD_BREAKPOINT_ORDER) {
-    if (boundedWidth >= breakpoints[breakpoint]) {
+    if (layoutWidth >= breakpoints[breakpoint]) {
       return breakpoint;
     }
   }
@@ -32,18 +26,18 @@ export const calculateDashboardRowHeight = (
   viewportWidth: number,
   breakpoint: DashboardViewportBreakpoint
 ): number => {
-  const boundedWidth = getDashboardLayoutViewportWidth(viewportWidth);
+  const layoutWidth = getDashboardLayoutViewportWidth(viewportWidth);
   const columnCount = cols[breakpoint] || cols.lg;
   const totalPadding = GRID.CONTAINER_PADDING * 2;
   const totalMargins = GRID.ITEM_MARGIN * (columnCount - 1);
-  const usableWidth = Math.max(boundedWidth - totalPadding - totalMargins, columnCount);
+  const usableWidth = Math.max(layoutWidth - totalPadding - totalMargins, columnCount);
   const columnWidth = usableWidth / columnCount;
 
-  if (boundedWidth < 600) {
+  if (layoutWidth < 600) {
     return columnWidth * 0.8;
   }
 
-  if (boundedWidth < 1200) {
+  if (layoutWidth < 1200) {
     return columnWidth * 0.9;
   }
 

--- a/src/lib/jsonResponseGuard.ts
+++ b/src/lib/jsonResponseGuard.ts
@@ -1,0 +1,66 @@
+const HTML_RESPONSE_PATTERN = /^\s*(?:<!doctype html|<html[\s>])/i;
+const RESPONSE_JSON_GUARD_INSTALLED = Symbol.for('boxento.response-json-guard.installed');
+
+type GuardedResponsePrototype = typeof Response.prototype & {
+  [RESPONSE_JSON_GUARD_INSTALLED]?: true;
+};
+
+const getStatusLabel = (response?: Response) => {
+  if (!response || response.status === 0) return '';
+
+  return ` (HTTP ${response.status})`;
+};
+
+const getContentType = (response?: Response) => (
+  response?.headers.get('content-type')?.toLowerCase() ?? ''
+);
+
+export const getJsonResponseParseErrorMessage = (
+  body: string,
+  response?: Response,
+  sourceLabel = 'The API endpoint',
+) => {
+  const trimmedBody = body.trim();
+  const statusLabel = getStatusLabel(response);
+
+  if (!trimmedBody) {
+    return `${sourceLabel} returned an empty response instead of JSON${statusLabel}. Check the API URL or backend response.`;
+  }
+
+  const contentType = getContentType(response);
+  const returnedHtml = contentType.includes('text/html') || HTML_RESPONSE_PATTERN.test(trimmedBody);
+
+  if (returnedHtml) {
+    return `${sourceLabel} returned HTML instead of JSON${statusLabel}. Check the API URL, backend proxy, or authentication.`;
+  }
+
+  return `${sourceLabel} returned invalid JSON${statusLabel}. Check the API URL or backend response.`;
+};
+
+export const parseJsonResponseText = <T>(
+  body: string,
+  response?: Response,
+  sourceLabel?: string,
+): T => {
+  try {
+    return JSON.parse(body.trim()) as T;
+  } catch {
+    throw new SyntaxError(getJsonResponseParseErrorMessage(body, response, sourceLabel));
+  }
+};
+
+export const installJsonResponseGuard = () => {
+  if (typeof Response === 'undefined') return;
+
+  const prototype = Response.prototype as GuardedResponsePrototype;
+  if (prototype[RESPONSE_JSON_GUARD_INSTALLED]) return;
+
+  prototype.json = async function guardedJson(this: Response) {
+    const body = await this.text();
+    return parseJsonResponseText<unknown>(body, this);
+  };
+
+  Object.defineProperty(prototype, RESPONSE_JSON_GUARD_INSTALLED, {
+    value: true,
+  });
+};

--- a/src/lib/jsonResponseGuard.ts
+++ b/src/lib/jsonResponseGuard.ts
@@ -1,9 +1,4 @@
 const HTML_RESPONSE_PATTERN = /^\s*(?:<!doctype html|<html[\s>])/i;
-const RESPONSE_JSON_GUARD_INSTALLED = Symbol.for('boxento.response-json-guard.installed');
-
-type GuardedResponsePrototype = typeof Response.prototype & {
-  [RESPONSE_JSON_GUARD_INSTALLED]?: true;
-};
 
 const getStatusLabel = (response?: Response) => {
   if (!response || response.status === 0) return '';
@@ -47,20 +42,4 @@ export const parseJsonResponseText = <T>(
   } catch {
     throw new SyntaxError(getJsonResponseParseErrorMessage(body, response, sourceLabel));
   }
-};
-
-export const installJsonResponseGuard = () => {
-  if (typeof Response === 'undefined') return;
-
-  const prototype = Response.prototype as GuardedResponsePrototype;
-  if (prototype[RESPONSE_JSON_GUARD_INSTALLED]) return;
-
-  prototype.json = async function guardedJson(this: Response) {
-    const body = await this.text();
-    return parseJsonResponseText<unknown>(body, this);
-  };
-
-  Object.defineProperty(prototype, RESPONSE_JSON_GUARD_INSTALLED, {
-    value: true,
-  });
 };

--- a/src/lib/widgetConfigPersistence.ts
+++ b/src/lib/widgetConfigPersistence.ts
@@ -1,0 +1,19 @@
+import type { Widget } from '@/types';
+
+export type WidgetConfigPersistenceOptions = {
+  configWidgetIdsToSave?: Iterable<string>;
+  persistAllConfigs?: boolean;
+};
+
+export const getConfigWidgetIdsToSave = (
+  widgets: Widget[],
+  options: WidgetConfigPersistenceOptions,
+): string[] => {
+  if (options.persistAllConfigs) {
+    return widgets
+      .filter(widget => widget.id && widget.config)
+      .map(widget => widget.id);
+  }
+
+  return Array.from(new Set(options.configWidgetIdsToSave ?? []));
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,9 +8,6 @@ import { SafeSyncProvider } from './lib/SyncContext'
 import { AppSettingsProvider } from './context/AppSettingsContext'
 import { StorageContextProvider } from './lib/storage/StorageContext'
 import { SharedDashboardView } from './components/dashboard/SharedDashboardView'
-import { installJsonResponseGuard } from './lib/jsonResponseGuard'
-
-installJsonResponseGuard()
 
 window.addEventListener('vite:preloadError', (event) => {
   event.preventDefault()

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,22 @@ import { SafeSyncProvider } from './lib/SyncContext'
 import { AppSettingsProvider } from './context/AppSettingsContext'
 import { StorageContextProvider } from './lib/storage/StorageContext'
 import { SharedDashboardView } from './components/dashboard/SharedDashboardView'
+import { installJsonResponseGuard } from './lib/jsonResponseGuard'
+
+installJsonResponseGuard()
+
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault()
+
+  const reloadKey = 'boxento-preload-error-last-reload'
+  const lastReload = Number(window.sessionStorage.getItem(reloadKey) || 0)
+  const now = Date.now()
+
+  if (now - lastReload > 10000) {
+    window.sessionStorage.setItem(reloadKey, String(now))
+    window.location.reload()
+  }
+})
 
 const rootElement = document.getElementById('root')
 if (!rootElement) throw new Error('Failed to find the root element')

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -55,6 +55,63 @@ const readStoredLayoutX = async (page: Page, widgetId: string) => (
   }, [PERSONAL_DASHBOARD_STORAGE_KEYS.layouts, widgetId] as const)
 );
 
+const mockWeatherApi = async (page: Page) => {
+  await page.route('https://geocoding-api.open-meteo.com/**', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      status: 200,
+      body: JSON.stringify({
+        results: [
+          {
+            id: 5128581,
+            name: 'New York',
+            country: 'United States',
+            latitude: 40.7128,
+            longitude: -74.006,
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route('https://api.open-meteo.com/**', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      status: 200,
+      body: JSON.stringify({
+        current: {
+          temperature_2m: 22,
+          relative_humidity_2m: 65,
+          apparent_temperature: 24,
+          weather_code: 0,
+          wind_speed_10m: 5.2,
+          wind_direction_10m: 120,
+        },
+        daily: {
+          time: ['2026-03-16', '2026-03-17', '2026-03-18', '2026-03-19', '2026-03-20'],
+          weather_code: [0, 2, 3, 61, 80],
+          temperature_2m_max: [24, 26, 28, 27, 25],
+          temperature_2m_min: [18, 17, 19, 20, 18],
+          sunrise: [
+            '2026-03-16T06:30:00-04:00',
+            '2026-03-17T06:29:00-04:00',
+            '2026-03-18T06:27:00-04:00',
+            '2026-03-19T06:26:00-04:00',
+            '2026-03-20T06:24:00-04:00',
+          ],
+          sunset: [
+            '2026-03-16T19:08:00-04:00',
+            '2026-03-17T19:09:00-04:00',
+            '2026-03-18T19:10:00-04:00',
+            '2026-03-19T19:11:00-04:00',
+            '2026-03-20T19:12:00-04:00',
+          ],
+        },
+      }),
+    });
+  });
+};
+
 const readFirstTextNodeCenter = async (locator: Locator) => (
   locator.evaluate((element) => {
     const walker = document.createTreeWalker(
@@ -343,7 +400,93 @@ test('keeps the weather resize preview from jumping to a layout branch that will
   await expect(widget.getByText('Sunset', { exact: true })).toHaveCount(0);
 });
 
-test('keeps widget geometry stable when switching from laptop to 4K-class viewports', async ({ page }) => {
+test('renders narrow weather widgets without a clipped title header', async ({ page }) => {
+  await mockWeatherApi(page);
+  await page.setViewportSize({ width: 1512, height: 982 });
+
+  await seedDashboard(page, {
+    widgets: [
+      {
+        id: 'weather-narrow',
+        type: 'weather',
+        config: {
+          location: 'New York',
+          units: 'metric',
+        },
+      },
+    ],
+    layouts: {
+      lg: [
+        { i: 'weather-narrow', x: 0, y: 0, w: 1, h: 3, minW: 1, minH: 1 },
+      ],
+    },
+  });
+
+  const widget = page.locator('.react-grid-item[data-widget-id="weather-narrow"]');
+  await expect(widget).toBeVisible();
+  await expect(widget.getByText('New York')).toBeVisible();
+  await expect(widget.locator('.widget-header')).toHaveCount(0);
+  await expect(widget.getByRole('heading', { name: 'Weather' })).toHaveCount(0);
+});
+
+test('keeps failed widget fallbacks draggable and removable', async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 982 });
+
+  await seedDashboard(page, {
+    widgets: [
+      {
+        id: 'broken-widget',
+        type: 'missing-widget-type',
+        config: {},
+      },
+    ],
+    layouts: {
+      lg: [
+        { i: 'broken-widget', x: 0, y: 0, w: 3, h: 3, minW: 1, minH: 1 },
+      ],
+    },
+  });
+
+  const widget = page.locator('.react-grid-item[data-widget-id="broken-widget"]');
+  await expect(widget).toBeVisible();
+  await expect(widget.getByText('Widget Error')).toBeVisible();
+  await expect(widget.getByRole('button', { name: 'Remove widget' })).toBeVisible();
+
+  const dragHandle = widget.locator('[data-testid="widget-error-fallback"]');
+  const dragBox = await dragHandle.boundingBox();
+  if (!dragBox) {
+    throw new Error('Failed widget fallback drag handle is not available');
+  }
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await page.mouse.move(dragBox.x + dragBox.width / 2, dragBox.y + 40);
+    await page.mouse.down();
+    await page.mouse.move(dragBox.x + dragBox.width / 2 + 260, dragBox.y + 52, { steps: 12 });
+    await page.mouse.up();
+
+    const moved = await expect
+      .poll(async () => readStoredLayoutX(page, 'broken-widget'), { timeout: 2000 })
+      .toBeGreaterThan(0)
+      .then(() => true)
+      .catch(() => false);
+
+    if (moved) {
+      break;
+    }
+  }
+
+  expect(await readStoredLayoutX(page, 'broken-widget')).toBeGreaterThan(0);
+
+  await widget.getByRole('button', { name: 'Remove widget' }).click();
+  await expect(widget).toHaveCount(0);
+
+  await expect.poll(async () => {
+    const storedWidgets = await readStoredWidgets(page);
+    return storedWidgets.some((entry) => entry.id === 'broken-widget');
+  }).toBe(false);
+});
+
+test('uses the full dashboard canvas on 4K-class viewports without rewriting saved layouts', async ({ page }) => {
   await page.setViewportSize({ width: 1512, height: 982 });
 
   const widgets = Array.from({ length: 4 }, (_, index) => ({
@@ -397,6 +540,9 @@ test('keeps widget geometry stable when switching from laptop to 4K-class viewpo
 
   await expect(page.locator('.react-grid-item')).toHaveCount(4);
   const laptopGeometry = await captureRenderedLayout();
+  const laptopGridWidth = await page.locator('.react-grid-layout').evaluate((element) => (
+    Math.round(element.getBoundingClientRect().width)
+  ));
   const storedBefore = await page.evaluate(() => JSON.parse(localStorage.getItem('boxento-layouts-personal') || '{}'));
 
   await page.setViewportSize({ width: 2560, height: 1440 });
@@ -404,9 +550,14 @@ test('keeps widget geometry stable when switching from laptop to 4K-class viewpo
 
   await expect(page.locator('.react-grid-item')).toHaveCount(4);
   const externalDisplayGeometry = await captureRenderedLayout();
+  const externalGridWidth = await page.locator('.react-grid-layout').evaluate((element) => (
+    Math.round(element.getBoundingClientRect().width)
+  ));
   const storedAfter = await page.evaluate(() => JSON.parse(localStorage.getItem('boxento-layouts-personal') || '{}'));
 
-  expect(externalDisplayGeometry).toEqual(laptopGeometry);
+  expect(externalGridWidth).toBeGreaterThan(laptopGridWidth + 500);
+  expect(externalDisplayGeometry).not.toEqual(laptopGeometry);
+  expect(externalDisplayGeometry.at(-1)?.x ?? 0).toBeGreaterThan(laptopGeometry.at(-1)?.x ?? 0);
   expect(storedAfter).toEqual(storedBefore);
 });
 
@@ -895,7 +1046,7 @@ test('renders audited 1x1 widgets without header chrome', async ({ page }) => {
   await expect(clocksWidget).toBeVisible();
   await expect(clocksWidget.getByRole('heading', { name: 'World Clocks' })).toHaveCount(0);
   await expect(clocksWidget).toContainText('Mexico');
-  expect(await readOverflowingLeafNodes(page, 'world-clocks-1')).toEqual([]);
+  await expect.poll(async () => readOverflowingLeafNodes(page, 'world-clocks-1')).toEqual([]);
 
   const yearProgressWidget = page.locator('.react-grid-item[data-widget-id="year-progress-1"]');
   await expect(yearProgressWidget).toBeVisible();
@@ -961,6 +1112,6 @@ test('keeps world clock audit layouts within bounds from 1x1 through 4x4', async
   for (const widgetId of ['world-clocks-1', 'world-clocks-2', 'world-clocks-3', 'world-clocks-4']) {
     const widget = page.locator(`.react-grid-item[data-widget-id="${widgetId}"]`);
     await expect(widget).toBeVisible();
-    expect(await readOverflowingLeafNodes(page, widgetId)).toEqual([]);
+    await expect.poll(async () => readOverflowingLeafNodes(page, widgetId)).toEqual([]);
   }
 });

--- a/tests/e2e/monitoring-widgets.spec.ts
+++ b/tests/e2e/monitoring-widgets.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+import { seedDashboard } from './helpers/dashboardSeed';
+
+test('monitoring widgets explain HTML API responses and keep settings reachable', async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  await page.route('**/api/monitoring/**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<!doctype html><html><body>Boxento app shell</body></html>',
+    });
+  });
+  await page.route('**/api/cron-health-html', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<!doctype html><html><body>Boxento app shell</body></html>',
+    });
+  });
+
+  await seedDashboard(page, {
+    widgets: [
+      { id: 'kuma-1', type: 'kuma', config: { title: 'Service Monitoring' } },
+      { id: 'healthchecks-1', type: 'healthchecks', config: { title: 'Job Monitoring' } },
+      { id: 'cron-health-1', type: 'cron-health', config: { title: 'System Health', apiUrl: '/api/cron-health-html' } },
+    ],
+    layouts: {
+      lg: [
+        { i: 'kuma-1', x: 0, y: 0, w: 3, h: 4, minW: 2, minH: 2 },
+        { i: 'healthchecks-1', x: 3, y: 0, w: 3, h: 4, minW: 2, minH: 2 },
+        { i: 'cron-health-1', x: 6, y: 0, w: 3, h: 4, minW: 2, minH: 2 },
+      ],
+    },
+  });
+
+  const kuma = page.locator('.react-grid-item[data-widget-id="kuma-1"]');
+  await expect(kuma.getByText('Uptime Kuma endpoint returned HTML instead of JSON')).toBeVisible();
+  await kuma.getByRole('button', { name: 'Settings', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: 'Service Monitoring Settings' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete Widget' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  const healthchecks = page.locator('.react-grid-item[data-widget-id="healthchecks-1"]');
+  await expect(healthchecks.getByText('Healthchecks endpoint returned HTML instead of JSON')).toBeVisible();
+  await healthchecks.getByRole('button', { name: 'Settings', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: 'Job Monitoring Settings' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Delete Widget' })).toBeVisible();
+  await page.getByRole('button', { name: 'Cancel' }).click();
+
+  const cronHealth = page.locator('.react-grid-item[data-widget-id="cron-health-1"]');
+  await expect(cronHealth.getByText('The API endpoint returned HTML instead of JSON')).toBeVisible();
+});

--- a/tests/unit/dashboardLayouts.test.ts
+++ b/tests/unit/dashboardLayouts.test.ts
@@ -149,7 +149,7 @@ describe('dashboardLayouts', () => {
     ]);
   });
 
-  it('keeps wide layouts empty when only a laptop layout is persisted', () => {
+  it('hydrates missing wide layouts from a persisted laptop layout', () => {
     const lgLayout = [
       createLayoutItem({ i: 'left', x: 0, y: 0, w: 3, h: 3 }),
       createLayoutItem({ i: 'right', x: 9, y: 0, w: 3, h: 3 }),
@@ -158,12 +158,21 @@ describe('dashboardLayouts', () => {
     const validated = validateLayouts({ lg: lgLayout }, { rebalanceWideSparse: true });
 
     expect(validated.lg).toEqual(lgLayout);
-    expect(validated.xl).toEqual([]);
-    expect(validated.xxl).toEqual([]);
-    expect(validated.xxxl).toEqual([]);
+    expect(validated.xl.map((item) => [item.i, item.x, item.w])).toEqual([
+      ['left', 0, 7],
+      ['right', 7, 7],
+    ]);
+    expect(validated.xxl.map((item) => [item.i, item.x, item.w])).toEqual([
+      ['left', 0, 9],
+      ['right', 9, 9],
+    ]);
+    expect(validated.xxxl.map((item) => [item.i, item.x, item.w])).toEqual([
+      ['left', 0, 12],
+      ['right', 12, 12],
+    ]);
   });
 
-  it('keeps laptop-only saved layouts stable across repeated validation passes', () => {
+  it('keeps generated wide layouts stable across repeated validation passes', () => {
     const savedLayouts = {
       lg: [
         createLayoutItem({ i: 'a', x: 0, y: 0, w: 3, h: 3 }),
@@ -187,9 +196,9 @@ describe('dashboardLayouts', () => {
     expect(secondPass).toEqual(firstPass);
     expect(firstPass.md).toEqual([]);
     expect(firstPass.sm).toEqual([]);
-    expect(secondPass.xl).toEqual([]);
-    expect(secondPass.xxl).toEqual([]);
-    expect(secondPass.xxxl).toEqual([]);
+    expect(secondPass.xl.length).toBe(4);
+    expect(secondPass.xxl.length).toBe(4);
+    expect(secondPass.xxxl.length).toBe(4);
   });
 
   it('preserves authored wide-screen layouts instead of rescaling them from laptop layouts', () => {

--- a/tests/unit/dashboardViewport.test.ts
+++ b/tests/unit/dashboardViewport.test.ts
@@ -1,28 +1,30 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  DASHBOARD_LAYOUT_MAX_WIDTH,
   calculateDashboardRowHeight,
   getDashboardBreakpointForWidth,
   getDashboardLayoutViewportWidth,
 } from '@/lib/dashboardViewport';
 
 describe('dashboardViewport', () => {
-  it('caps desktop layout width on large external displays', () => {
+  it('uses the full layout width on large external displays', () => {
     expect(getDashboardLayoutViewportWidth(1512)).toBe(1512);
-    expect(getDashboardLayoutViewportWidth(2560)).toBe(DASHBOARD_LAYOUT_MAX_WIDTH);
+    expect(getDashboardLayoutViewportWidth(2560)).toBe(2560);
+    expect(getDashboardLayoutViewportWidth(3840)).toBe(3840);
   });
 
-  it('keeps large external displays on the laptop-class dashboard breakpoint', () => {
+  it('uses wide dashboard breakpoints on large external displays', () => {
     expect(getDashboardBreakpointForWidth(1512)).toBe('lg');
-    expect(getDashboardBreakpointForWidth(2560)).toBe('lg');
+    expect(getDashboardBreakpointForWidth(1536)).toBe('xl');
+    expect(getDashboardBreakpointForWidth(1920)).toBe('xxl');
+    expect(getDashboardBreakpointForWidth(2560)).toBe('xxxl');
     expect(getDashboardBreakpointForWidth(767)).toBe('xs');
   });
 
-  it('uses the bounded dashboard width for row height calculations', () => {
+  it('uses the full dashboard width for row height calculations', () => {
     const laptopRowHeight = calculateDashboardRowHeight(1512, 'lg');
-    const externalDisplayRowHeight = calculateDashboardRowHeight(2560, 'lg');
+    const externalDisplayRowHeight = calculateDashboardRowHeight(3840, 'xxxl');
 
-    expect(externalDisplayRowHeight).toBe(laptopRowHeight);
+    expect(externalDisplayRowHeight).toBeGreaterThan(laptopRowHeight);
   });
 });

--- a/tests/unit/jsonResponseGuard.test.ts
+++ b/tests/unit/jsonResponseGuard.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   getJsonResponseParseErrorMessage,
-  installJsonResponseGuard,
   parseJsonResponseText,
 } from '@/lib/jsonResponseGuard';
 
@@ -22,15 +21,13 @@ describe('jsonResponseGuard', () => {
     );
   });
 
-  it('makes response.json failures readable app-wide', async () => {
-    installJsonResponseGuard();
-
+  it('formats explicit parse failures without patching Response.json', () => {
     const response = new Response('<html><body>Not JSON</body></html>', {
       status: 404,
       headers: { 'content-type': 'text/html' },
     });
 
-    await expect(response.json()).rejects.toThrow(
+    expect(() => parseJsonResponseText('<html><body>Not JSON</body></html>', response)).toThrow(
       'The API endpoint returned HTML instead of JSON (HTTP 404). Check the API URL, backend proxy, or authentication.',
     );
   });

--- a/tests/unit/jsonResponseGuard.test.ts
+++ b/tests/unit/jsonResponseGuard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getJsonResponseParseErrorMessage,
+  installJsonResponseGuard,
+  parseJsonResponseText,
+} from '@/lib/jsonResponseGuard';
+
+describe('jsonResponseGuard', () => {
+  it('parses valid JSON text', () => {
+    expect(parseJsonResponseText<{ ok: boolean }>('{"ok":true}')).toEqual({ ok: true });
+  });
+
+  it('identifies HTML responses without exposing query strings', () => {
+    const response = new Response('<!doctype html><html><body>Login</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+
+    expect(getJsonResponseParseErrorMessage('<!doctype html>', response, 'Widget API')).toBe(
+      'Widget API returned HTML instead of JSON (HTTP 200). Check the API URL, backend proxy, or authentication.',
+    );
+  });
+
+  it('makes response.json failures readable app-wide', async () => {
+    installJsonResponseGuard();
+
+    const response = new Response('<html><body>Not JSON</body></html>', {
+      status: 404,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    await expect(response.json()).rejects.toThrow(
+      'The API endpoint returned HTML instead of JSON (HTTP 404). Check the API URL, backend proxy, or authentication.',
+    );
+  });
+});

--- a/tests/unit/monitoringApiResponse.test.ts
+++ b/tests/unit/monitoringApiResponse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { readMonitoringJson } from '@/components/widgets/common/monitoringApiResponse';
+
+describe('readMonitoringJson', () => {
+  it('returns parsed JSON for successful monitoring responses', async () => {
+    const response = new Response(JSON.stringify({ monitors: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(readMonitoringJson<{ monitors: unknown[] }>(response, 'Uptime Kuma')).resolves.toEqual({
+      monitors: [],
+    });
+  });
+
+  it('uses JSON error payloads from failed responses', async () => {
+    const response = new Response(JSON.stringify({ error: 'Monitoring is not configured' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await expect(readMonitoringJson(response, 'Healthchecks')).rejects.toThrow('Monitoring is not configured');
+  });
+
+  it('explains when a frontend HTML page is returned instead of widget API JSON', async () => {
+    const response = new Response('<!doctype html><html><body>Boxento</body></html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+
+    await expect(readMonitoringJson(response, 'Uptime Kuma')).rejects.toThrow(
+      'Uptime Kuma endpoint returned HTML instead of JSON',
+    );
+  });
+});

--- a/tests/unit/widgetConfigPersistence.test.ts
+++ b/tests/unit/widgetConfigPersistence.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getConfigWidgetIdsToSave } from '@/lib/widgetConfigPersistence';
+import type { Widget } from '@/types';
+
+const createWidget = (
+  id: string,
+  config?: Record<string, unknown>,
+): Widget => ({
+  id,
+  type: 'notes',
+  config,
+});
+
+describe('widgetConfigPersistence', () => {
+  it('saves all widget configs for legacy full persistence paths', () => {
+    expect(getConfigWidgetIdsToSave([
+      createWidget('a', { title: 'A' }),
+      createWidget('b'),
+      createWidget('c', { title: 'C' }),
+    ], { persistAllConfigs: true })).toEqual(['a', 'c']);
+  });
+
+  it('saves only targeted configs for optimized widget updates', () => {
+    expect(getConfigWidgetIdsToSave([
+      createWidget('a', { title: 'A' }),
+      createWidget('b', { title: 'B' }),
+    ], { configWidgetIdsToSave: ['b', 'b'] })).toEqual(['b']);
+  });
+
+  it('does not resave configs when no targeted ids are requested', () => {
+    expect(getConfigWidgetIdsToSave([
+      createWidget('a', { title: 'A' }),
+    ], {})).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,14 @@ import { execSync } from 'child_process'
 
 // Get git commit hash for build versioning
 const getGitHash = () => {
+  if (process.env.VITE_BUILD_HASH) {
+    return process.env.VITE_BUILD_HASH
+  }
+
   try {
-    return execSync('git rev-parse --short HEAD').toString().trim()
+    return execSync('git rev-parse --short HEAD', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim()
   } catch {
     return 'unknown'
   }


### PR DESCRIPTION
## Summary
This PR prepares Boxento for dashboards with thousands of widgets by reducing unnecessary widget work, improving layout persistence, and adding benchmark/readiness documentation. It also fixes widget-system regressions found during the browser audit so performance improvements do not break existing widget behavior or visual styling.

## What Changed
- Adds a dashboard performance benchmark and readiness doc with targets for large widget counts.
- Defers offscreen widget frame work and reduces duplicate widget/layout persistence updates.
- Removes the laptop-width dashboard cap so wide and 4K displays use the proper wide breakpoints.
- Updates service worker and Vite preload recovery so stale widget chunks recover cleanly.
- Keeps failed/unknown widgets draggable, reloadable where appropriate, and removable.
- Applies the Boxento widget size contract across audited widgets: tiny headers, compact setup/error states, world clock grids, Pomodoro panel sizing, QR Code app select sizing, Year Progress compact sizing, and narrow Weather header clipping.
- Adds JSON response guards for monitoring widgets so HTML, empty, or invalid API responses show scoped recovery messages instead of raw parser failures.
- Prepares Docker builds for review by installing frontend dependencies from `bun.lock`, excluding generated/nested dependency artifacts from the Docker context, and supporting explicit Docker build hashes.

## How to Test
- `bun run build:types`
- `bun run build`
- `bunx vitest run`
- `node scripts/run-playwright.mjs`
- `docker build --build-arg VITE_BUILD_HASH=$(git rev-parse --short HEAD) -t boxento-pr136 .`
- `docker run --rm -d --name boxento-pr136-test -p 5174:5173 boxento-pr136`, then `curl -I http://localhost:5174`
- Browser audit: 31 widgets across 1x1, 2x2, 3x3, 4x4, and 6x6 sizes, covering 155 rendered surfaces.
- GitHub Actions passed on head `7a72d73`: CodeQL, app-tests, and Docker Image CI/CD build.

## Risks / Rollout Notes
- Service worker behavior changed to avoid stale app shell and chunk caching; deploy should be verified on `boxento.app` after GitHub Actions are green.
- Wide dashboard layouts now hydrate from saved laptop layouts instead of staying empty on 4K-class displays.
- Existing lint warnings remain in several widget files; no lint errors were introduced.
- Vite still reports the existing large vendor chunk warning during production build.
- Docker ARG warnings for Firebase build-time values are pre-existing and still emitted by Docker.

## Review Focus
- Dashboard layout hydration and persistence in `src/lib/dashboardLayouts.ts` and `src/App.tsx`.
- Service worker caching and stale chunk recovery in `public/service-worker.js` and `src/main.tsx`.
- Widget fallback behavior in `src/components/dashboard/DashboardWidgetFrame.tsx` and `src/components/widgets/common/WidgetErrorBoundary.tsx`.
- Widget size contract fixes in the updated widget files.
- Docker install/context/build-version behavior in `Dockerfile`, `.dockerignore`, and `vite.config.ts`.

## PM Notes
- Users can add and resize many widgets with less UI work on initial dashboard render.
- Existing widget styling is preserved: no new hover effects, borders, shadows, or visual treatments were added.
- Broken widget chunks or unknown widget types no longer trap users; they can drag and remove those widgets.
- Tiny and compact widget states remain legible instead of clipping headers or overflowing setup/error text.
- Docker packaging is more deterministic because frontend dependencies now follow the committed lockfile.
