### PR TITLE
Polish large monitoring widget layouts

### DIFF
--- a/src/components/widgets/HealthchecksWidget/index.tsx
+++ b/src/components/widgets/HealthchecksWidget/index.tsx
@@ -420,18 +420,18 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
         key={check.slug}
         onClick={() => setSelectedCheckSlug(check.slug)}
         className={cn(
-          'w-full rounded-lg border border-border/60 bg-background/40 text-left transition-colors hover:bg-accent/50',
+          'w-full justify-start rounded-lg border border-border/60 bg-background/40 text-left transition-colors hover:bg-accent/50',
           compact ? 'px-2 py-2' : 'px-3 py-2',
           selected && 'border-primary/40 bg-accent/50',
         )}
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1">
+        <div className="flex w-full min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-1">
             <div className="flex items-center gap-2">
               <StatusIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
               <span className="truncate text-sm font-medium text-foreground">{check.name}</span>
             </div>
-            <div className="text-xs text-muted-foreground">
+            <div className="truncate text-xs text-muted-foreground">
               {localConfig.showTags && check.tags ? `${check.tags} · ` : ''}{check.slug}
             </div>
             {!compact && localConfig.showDescription && check.description && (
@@ -465,7 +465,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
     const StatusIcon = statusStyle.icon;
 
     return (
-      <div className="flex h-full flex-col gap-4 p-4">
+      <div className="flex h-full min-h-0 flex-col gap-4 overflow-auto p-4">
         <div className="space-y-2">
           <div className="flex items-center gap-2">
             <StatusIcon className="h-5 w-5 text-muted-foreground" />

--- a/src/components/widgets/KumaWidget/index.tsx
+++ b/src/components/widgets/KumaWidget/index.tsx
@@ -406,18 +406,18 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
         key={monitor.id}
         onClick={() => setSelectedMonitorId(monitor.id)}
         className={cn(
-          'w-full rounded-lg border border-border/60 bg-background/40 text-left transition-colors hover:bg-accent/50',
+          'w-full justify-start rounded-lg border border-border/60 bg-background/40 text-left transition-colors hover:bg-accent/50',
           compact ? 'px-2 py-2' : 'px-3 py-2',
           selected && 'border-primary/40 bg-accent/50',
         )}
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0 space-y-1">
+        <div className="flex w-full min-w-0 items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-1">
             <div className="flex items-center gap-2">
               <StatusIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
               <span className="truncate text-sm font-medium text-foreground">{monitor.name}</span>
             </div>
-            <div className="text-xs text-muted-foreground">
+            <div className="truncate text-xs text-muted-foreground">
               {localConfig.showGroups ? `${monitor.group} · ` : ''}{monitor.type}
             </div>
             {!compact && localConfig.showMessages && monitor.message && (
@@ -451,7 +451,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
     const StatusIcon = statusStyle.icon;
 
     return (
-      <div className="flex h-full flex-col gap-4 p-4">
+      <div className="flex h-full min-h-0 flex-col gap-4 overflow-auto p-4">
         <div className="space-y-2">
           <div className="flex items-center gap-2">
             <StatusIcon className="h-5 w-5 text-muted-foreground" />

--- a/src/components/widgets/ServicesWidget/index.tsx
+++ b/src/components/widgets/ServicesWidget/index.tsx
@@ -188,7 +188,8 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
   const isCompact = width <= 2 || height <= 2;
   const isWide = width >= 4;
   const isTall = height >= 4;
-  const isApp = width >= 6 && height >= 6;
+  const isApp = width >= 8 && height >= 6;
+  const isDirectory = width >= 6 && height >= 6;
   const readOnly = config?.readOnly ?? false;
 
   const mergedConfig = useMemo(() => mergeConfigWithDefaults(config), [config]);
@@ -326,6 +327,19 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     if (!selectedServiceId) return null;
     return localConfig.services.find(s => s.id === selectedServiceId) || null;
   }, [localConfig.services, selectedServiceId]);
+
+  useEffect(() => {
+    if (!filteredServices.length) {
+      setSelectedServiceId(null);
+      return;
+    }
+
+    setSelectedServiceId(current =>
+      current && filteredServices.some(service => service.id === current)
+        ? current
+        : filteredServices[0].id
+    );
+  }, [filteredServices]);
 
   const getGridColumns = (measuredWidth: number) => {
     if (measuredWidth >= 1500) return 5;
@@ -534,6 +548,134 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     );
   };
 
+  const renderDirectoryServiceRow = (service: Service) => {
+    const Icon = getIcon(service.icon);
+    const status = serviceStatus[service.id];
+    const StatusIcon = getStatusIcon(status);
+    const rt = responseTime[service.id];
+
+    return (
+      <Button type="button" variant="ghost" size="none"
+        key={service.id}
+        onClick={() => openService(service.url)}
+        className="flex w-full justify-start rounded-none border-b border-border/60 px-3 py-3 text-left transition-colors hover:bg-accent"
+      >
+        <div className="flex w-full min-w-0 items-center gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-card ring-1 ring-border">
+            <Icon className="h-4 w-4 text-foreground" />
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-sm font-medium text-foreground">{service.name}</span>
+              {localConfig.showStatus && (
+                <span className={cn('h-2 w-2 shrink-0 rounded-full', getStatusColor(status))} />
+              )}
+            </div>
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {service.description || getServiceHost(service.url)}
+            </div>
+          </div>
+
+          <div className="hidden min-w-0 flex-1 text-xs text-muted-foreground sm:block">
+            <div className="truncate">{getServiceHost(service.url)}</div>
+            {service.category && (
+              <div className="mt-1 truncate">{service.category}</div>
+            )}
+          </div>
+
+          <div className="flex shrink-0 items-center gap-3 text-xs text-muted-foreground">
+            {localConfig.showStatus && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-card px-2 py-1 ring-1 ring-border">
+                <StatusIcon className="h-3.5 w-3.5" />
+                {getStatusLabel(status)}
+              </span>
+            )}
+            {rt !== undefined && localConfig.showStatus && (
+              <span className="hidden items-center gap-1 sm:inline-flex">
+                <Clock className="h-3.5 w-3.5" />
+                {rt}ms
+              </span>
+            )}
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </div>
+        </div>
+      </Button>
+    );
+  };
+
+  const renderDirectory = () => (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <div className="space-y-3 px-3 py-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">{localConfig.services.length} services</span>
+            {localConfig.showStatus && (
+              <>
+                <span className="flex items-center gap-1">
+                  <div className="h-2 w-2 rounded-full bg-green-500" />
+                  {onlineCount} up
+                </span>
+                {offlineCount > 0 && (
+                  <span className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-red-500" />
+                    {offlineCount} down
+                  </span>
+                )}
+              </>
+            )}
+          </div>
+          <div className="relative min-w-[12rem] flex-1 sm:max-w-[18rem]">
+            <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Filter..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 pl-7 text-xs"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          <Button type="button" variant="ghost" size="none"
+            onClick={() => setSelectedCategory(null)}
+            className={cn(
+              'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
+              !selectedCategory && 'bg-accent text-foreground'
+            )}
+          >
+            All ({localConfig.services.length})
+          </Button>
+          {categories.map(cat => {
+            const count = localConfig.services.filter(s => s.category === cat).length;
+            return (
+              <Button type="button" variant="ghost" size="none"
+                key={cat}
+                onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
+                className={cn(
+                  'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
+                  selectedCategory === cat && 'bg-accent text-foreground'
+                )}
+              >
+                {cat} ({count})
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto border-t border-border/60">
+        {filteredServices.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            No services match filter
+          </div>
+        ) : (
+          filteredServices.map(service => renderDirectoryServiceRow(service))
+        )}
+      </div>
+    </div>
+  );
+
   // Panel (4x4-5x5): category sidebar + service grid
   const renderPanel = () => {
     const panelColumns = Math.min(getGridColumns(containerWidth * 0.65), Math.max(filteredServices.length, 1));
@@ -621,12 +763,12 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     );
   };
 
-  // App (6x6+): full service dashboard - master-detail with categories, search, response times
+  // App (8x6+): full service dashboard - master-detail with categories, search, response times
   const renderApp = () => {
     return (
-      <div className="flex h-full overflow-hidden">
+      <div className="flex h-full min-h-0 overflow-hidden">
         {/* Left sidebar: categories + service list */}
-        <div className="flex w-1/3 min-w-[200px] max-w-[320px] flex-col border-r border-border">
+        <div className="flex w-[38%] min-w-[260px] max-w-[420px] flex-col border-r border-border">
           {/* Search */}
           <div className="p-2 widget-drag-handle cursor-move">
             <div className="relative">
@@ -641,7 +783,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           </div>
 
           {/* Category filter tabs */}
-          <div className="flex items-center gap-1 overflow-x-auto px-2 py-1.5 border-b border-border">
+          <div className="flex flex-wrap items-center gap-1 px-2 py-1.5 border-b border-border">
             <Button type="button" variant="ghost" size="none"
               onClick={() => setSelectedCategory(null)}
               className={cn(
@@ -670,7 +812,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           </div>
 
           {/* Service list */}
-          <div className="flex-1 overflow-y-auto">
+          <div className="min-h-0 flex-1 overflow-y-auto">
             {filteredServices.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
                 <Search className="h-6 w-6" />
@@ -730,9 +872,9 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
         </div>
 
         {/* Right detail pane */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="min-w-0 flex-1 overflow-y-auto">
           {selectedService ? (
-            <div className="p-6">
+            <div className="p-5">
               {renderServiceDetail(selectedService)}
             </div>
           ) : (
@@ -778,16 +920,16 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     const rt = responseTime[service.id];
 
     return (
-      <div className="space-y-6">
+      <div className="min-w-0 space-y-6">
         {/* Header */}
-        <div className="flex items-start justify-between">
-          <div className="flex items-start gap-4">
+        <div className="flex min-w-0 items-start justify-between gap-4">
+          <div className="flex min-w-0 items-start gap-4">
             <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-card text-foreground shadow-sm ring-1 ring-border">
               <Icon className="h-7 w-7" />
             </div>
-            <div>
-              <h2 className="text-xl font-semibold text-foreground">{service.name}</h2>
-              <p className="text-sm text-muted-foreground mt-0.5">
+            <div className="min-w-0">
+              <h2 className="truncate text-xl font-semibold text-foreground">{service.name}</h2>
+              <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
                 {service.description || 'No description'}
               </p>
             </div>
@@ -823,22 +965,22 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
 
         {/* Connection details */}
         <div className="rounded-lg border border-border divide-y divide-border">
-          <div className="flex items-center justify-between px-4 py-3">
+          <div className="flex items-start justify-between gap-4 px-4 py-3">
             <span className="text-sm text-muted-foreground">URL</span>
             <a
               href={service.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm font-mono text-foreground hover:underline"
+              className="min-w-0 max-w-[72%] break-all text-right font-mono text-sm text-foreground hover:underline"
             >
               {service.url}
             </a>
           </div>
-          <div className="flex items-center justify-between px-4 py-3">
+          <div className="flex items-start justify-between gap-4 px-4 py-3">
             <span className="text-sm text-muted-foreground">Host</span>
-            <span className="text-sm text-foreground">{getServiceHost(service.url)}</span>
+            <span className="min-w-0 max-w-[72%] break-all text-right text-sm text-foreground">{getServiceHost(service.url)}</span>
           </div>
-          <div className="flex items-center justify-between px-4 py-3">
+          <div className="flex items-start justify-between gap-4 px-4 py-3">
             <span className="text-sm text-muted-foreground">Port</span>
             <span className="text-sm font-mono text-foreground">{getServicePort(service.url)}</span>
           </div>
@@ -1228,6 +1370,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           : isTiny ? renderTiny()
           : isShort ? renderShort()
           : isApp ? renderApp()
+          : isDirectory ? renderDirectory()
           : isWide && isTall ? renderPanel()
           : isCompact ? renderCompact()
           : renderDefault()}

--- a/tests/e2e/monitoring-widgets.spec.ts
+++ b/tests/e2e/monitoring-widgets.spec.ts
@@ -2,6 +2,108 @@ import { expect, test } from '@playwright/test';
 
 import { seedDashboard } from './helpers/dashboardSeed';
 
+const MOCK_KUMA_RESPONSE = {
+  dashboardUrl: 'https://kuma.test/status/homelab',
+  monitors: [
+    {
+      id: 1,
+      name: 'Fava backend (localhost)',
+      group: 'Mac Mini Services',
+      type: 'port',
+      status: 'up',
+      ping: 3,
+      message: 'OK',
+      lastChecked: '2026-05-22T22:34:00.000Z',
+      uptime24: 1,
+    },
+    {
+      id: 2,
+      name: 'OpenClaw backup',
+      group: 'Mac Mini Services',
+      type: 'http',
+      status: 'down',
+      ping: null,
+      message: 'HTTP 503 from upstream',
+      lastChecked: '2026-05-22T22:31:00.000Z',
+      uptime24: 0.92,
+    },
+    {
+      id: 3,
+      name: 'Paisa backend (localhost)',
+      group: 'Mac Mini Services',
+      type: 'port',
+      status: 'up',
+      ping: 30,
+      message: 'OK',
+      lastChecked: '2026-05-22T22:35:00.000Z',
+      uptime24: 1,
+    },
+  ],
+  summary: {
+    total: 3,
+    up: 2,
+    down: 1,
+    pending: 0,
+    maintenance: 0,
+  },
+  updatedAt: '2026-05-22T22:35:00.000Z',
+};
+
+const MOCK_HEALTHCHECKS_RESPONSE = {
+  dashboardUrl: 'https://healthchecks.test/projects/demo/checks',
+  checks: [
+    {
+      name: 'finance-sync',
+      slug: 'finance-sync',
+      tags: 'mac-mini finance nightly',
+      description: 'Syncs finance data every night.',
+      status: 'down',
+      started: false,
+      lastPing: '2026-05-22T02:00:00.000Z',
+      nextPing: '2026-05-23T02:00:00.000Z',
+      lastDuration: 134,
+      graceSeconds: 7200,
+      timeoutSeconds: 86400,
+    },
+    {
+      name: 'openclaw-backup',
+      slug: 'openclaw-backup',
+      tags: 'mac-mini backup',
+      description: 'Runs the OpenClaw backup.',
+      status: 'up',
+      started: false,
+      lastPing: '2026-05-22T21:00:00.000Z',
+      nextPing: '2026-05-23T21:00:00.000Z',
+      lastDuration: 32,
+      graceSeconds: 7200,
+      timeoutSeconds: 86400,
+    },
+    {
+      name: 'openclaw-backup-sync',
+      slug: 'openclaw-backup-sync',
+      tags: 'mac-mini backup sync',
+      description: 'Publishes backup sync status.',
+      status: 'up',
+      started: false,
+      lastPing: '2026-05-22T20:00:00.000Z',
+      nextPing: '2026-05-23T20:00:00.000Z',
+      lastDuration: 16,
+      graceSeconds: 7200,
+      timeoutSeconds: 86400,
+    },
+  ],
+  summary: {
+    total: 3,
+    up: 2,
+    down: 1,
+    grace: 0,
+    late: 0,
+    new: 0,
+    paused: 0,
+  },
+  updatedAt: '2026-05-22T22:35:00.000Z',
+};
+
 test('monitoring widgets explain HTML API responses and keep settings reachable', async ({ page }) => {
   await page.setViewportSize({ width: 1400, height: 900 });
   await page.route('**/api/monitoring/**', async (route) => {
@@ -50,4 +152,49 @@ test('monitoring widgets explain HTML API responses and keep settings reachable'
 
   const cronHealth = page.locator('.react-grid-item[data-widget-id="cron-health-1"]');
   await expect(cronHealth.getByText('The API endpoint returned HTML instead of JSON')).toBeVisible();
+});
+
+test('keeps tall monitoring widgets simple and list-focused', async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 982 });
+  await page.route('**/api/monitoring/kuma', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_KUMA_RESPONSE),
+    });
+  });
+  await page.route('**/api/monitoring/healthchecks', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_HEALTHCHECKS_RESPONSE),
+    });
+  });
+
+  await seedDashboard(page, {
+    widgets: [
+      { id: 'kuma-tall', type: 'kuma', config: { title: 'Service Monitoring' } },
+      { id: 'healthchecks-tall', type: 'healthchecks', config: { title: 'Job Monitoring' } },
+    ],
+    layouts: {
+      lg: [
+        { i: 'kuma-tall', x: 0, y: 0, w: 3, h: 6, minW: 1, minH: 1 },
+        { i: 'healthchecks-tall', x: 3, y: 0, w: 3, h: 6, minW: 1, minH: 1 },
+      ],
+    },
+  });
+
+  const kuma = page.locator('.react-grid-item[data-widget-id="kuma-tall"]');
+  await expect(kuma.getByText('OpenClaw backup')).toBeVisible();
+  await expect(kuma.getByText('HTTP 503 from upstream')).toBeVisible();
+  await expect(kuma.getByText('Updated')).toBeVisible();
+  await expect(kuma.getByPlaceholder('Search monitors')).toHaveCount(0);
+  await expect(kuma.getByText('Response time')).toHaveCount(0);
+
+  const healthchecks = page.locator('.react-grid-item[data-widget-id="healthchecks-tall"]');
+  await expect(healthchecks.getByRole('button', { name: /finance-sync/ }).first()).toBeVisible();
+  await expect(healthchecks.getByText('134s ·')).toBeVisible();
+  await expect(healthchecks.getByText('Updated')).toBeVisible();
+  await expect(healthchecks.getByPlaceholder('Search checks')).toHaveCount(0);
+  await expect(healthchecks.getByText('Last run')).toHaveCount(0);
 });

--- a/tests/e2e/services-widget.spec.ts
+++ b/tests/e2e/services-widget.spec.ts
@@ -147,3 +147,74 @@ test('persists services settings changes from the tablet dialog flow', async ({ 
   await expect(widget).toContainText(serviceToAdd.name);
   await expect(widget).not.toContainText(serviceToDelete);
 });
+
+test('keeps 6x6 services widgets as a simple searchable directory list', async ({ page }) => {
+  await page.route('https://*.test/**', (route) => route.fulfill({ status: 204, body: '' }));
+  await page.setViewportSize({ width: 1512, height: 982 });
+  await seedDashboard(page, {
+    widgets: [
+      {
+        id: 'services-app',
+        type: 'services',
+        config: {
+          title: 'Services',
+          services: SERVICES,
+          showStatus: true,
+          checkInterval: 60,
+        },
+      },
+    ],
+    layouts: {
+      lg: [
+        { i: 'services-app', x: 0, y: 0, w: 6, h: 6, minW: 1, minH: 1 },
+      ],
+    },
+  });
+
+  const widget = page.locator('.react-grid-item[data-widget-id="services-app"]');
+  await expect(widget.getByPlaceholder('Filter...')).toBeVisible();
+  await expect(widget.getByRole('button', { name: 'Utilities (1)' })).toBeVisible();
+  await expect(widget.getByRole('button', { name: /Boxento/ })).toBeVisible();
+  await expect(widget.getByText('boxento.test')).toBeVisible();
+  await expect(widget.getByText('Response Time')).toHaveCount(0);
+  await expect(widget.getByRole('link', { name: 'https://boxento.test' })).toHaveCount(0);
+});
+
+test('reserves the services detail pane for truly wide app sizes', async ({ page }) => {
+  await page.route('https://*.test/**', (route) => route.fulfill({ status: 204, body: '' }));
+  await page.setViewportSize({ width: 1512, height: 982 });
+  await seedDashboard(page, {
+    widgets: [
+      {
+        id: 'services-wide-app',
+        type: 'services',
+        config: {
+          title: 'Services',
+          services: SERVICES,
+          showStatus: true,
+          checkInterval: 60,
+        },
+      },
+    ],
+    layouts: {
+      lg: [
+        { i: 'services-wide-app', x: 0, y: 0, w: 8, h: 6, minW: 1, minH: 1 },
+      ],
+    },
+  });
+
+  const widget = page.locator('.react-grid-item[data-widget-id="services-wide-app"]');
+  await expect(widget.getByRole('button', { name: 'Utilities' })).toBeVisible();
+  await expect(widget.getByRole('link', { name: 'https://boxento.test' })).toBeVisible();
+  await expect(widget.getByText('Response Time')).toBeVisible();
+
+  const detailFitsWidget = await widget.getByRole('link', { name: 'https://boxento.test' }).evaluate((link) => {
+    const widget = link.closest('.react-grid-item');
+    if (!(widget instanceof HTMLElement)) return false;
+    const widgetRect = widget.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+    return linkRect.left >= widgetRect.left && linkRect.right <= widgetRect.right;
+  });
+
+  expect(detailFitsWidget).toBe(true);
+});


### PR DESCRIPTION
## Summary

Polishes the large-size UX for the self-hosted monitoring widgets without changing their core behavior or adding a heavier visual treatment. The change keeps Uptime Kuma and Healthchecks tall widgets list-focused, and makes the Services widget use a simpler 6x6 directory view instead of the detail-pane app view.

## What Changed

- Uptime Kuma and Healthchecks rows now use the full available row width, so names/metadata/status content clip less aggressively in tall widgets.
- Services now treats `6x6` as a searchable directory list with category chips and dense rows.
- Services reserves the master/detail pane for truly wide app sizes: `8x6+`.
- Services detail mode still wraps long URLs/hosts safely when the widget is wide enough to use that mode.
- Added Playwright coverage for tall monitoring widgets, 6x6 Services directory behavior, and 8x6 Services detail-pane behavior.

## How to Test

- `bun run lint`
  - exits successfully; existing repo warnings remain.
- `bun run build`
- `node scripts/run-playwright.mjs tests/e2e/monitoring-widgets.spec.ts tests/e2e/services-widget.spec.ts`

## Risks / Rollout Notes

- No registry sizing changes and no settings/destructive-flow changes.
- No migration required for hosted or Docker users.
- After merge and green GitHub Actions, boxento.app should be deployed from `main` and Docker users can pull the next image produced from the merged commit.

## Review Focus

- Confirm the `6x6` Services directory is intentionally simpler than the old app/detail pane.
- Confirm `8x6+` remains usable for users who want the richer Services detail view.
- Confirm monitoring rows remain visually consistent with existing widget styling and do not introduce new hover/shadow/border language.

## PM Notes

- Docker/self-hosted users get more readable monitoring widgets on large dashboards.
- Services at 6x6 now behaves like a clean launcher/status directory, not an admin console.
- Existing widget functionality, settings, deletion, refresh, and external-link behavior are preserved.
