### PR TITLE
Add tag-driven release management workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,8 +3,6 @@ name: Docker Image CI/CD
 on:
   push:
     branches: [ "main" ]
-    # Publish semver tags as releases
-    tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
 
@@ -37,19 +35,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
+      # Extract metadata (tags, labels) for Docker.
+      # Release tags and `latest` are published by release.yml so Docker
+      # users only get `latest` from an intentional release.
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
             type=sha
 
       # Build and push Docker image with Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tags must use vMAJOR.MINOR.PATCH, got: $TAG" >&2
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          PREVIOUS_TAG="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -n 1 || true)"
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=$PREVIOUS_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run lint
+        run: bun run lint
+
+      - name: Run unit tests
+        run: bun run test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run browser smoke tests
+        run: bun run test:e2e
+
+      - name: Build app
+        run: bun run build
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Generate GitHub release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+          PREVIOUS_TAG: ${{ steps.release.outputs.previous_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          NOTES_ARGS=(-f "tag_name=$TAG" -f "target_commitish=$GITHUB_SHA")
+          if [[ -n "$PREVIOUS_TAG" ]]; then
+            NOTES_ARGS+=(-f "previous_tag_name=$PREVIOUS_TAG")
+          fi
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" "${NOTES_ARGS[@]}" > generated-release-notes.json
+
+          {
+            echo "## Docker"
+            echo
+            echo "Published multi-architecture images for linux/amd64 and linux/arm64:"
+            echo
+            echo "- \`ghcr.io/${GITHUB_REPOSITORY}:${VERSION}\`"
+            echo "- \`ghcr.io/${GITHUB_REPOSITORY}:${VERSION%.*}\`"
+            echo "- \`ghcr.io/${GITHUB_REPOSITORY}:${VERSION%%.*}\`"
+            echo "- \`ghcr.io/${GITHUB_REPOSITORY}:latest\`"
+            echo "- \`ghcr.io/${GITHUB_REPOSITORY}:sha-${GITHUB_SHA::7}\`"
+            echo
+            echo "Update an existing Docker Compose install with:"
+            echo
+            echo "\`\`\`bash"
+            echo "docker compose pull"
+            echo "docker compose up -d"
+            echo "\`\`\`"
+            echo
+            echo "No database or volume migration is required unless noted below."
+            echo
+            echo "## Changes"
+            echo
+            jq -r '.body' generated-release-notes.json
+          } > release-notes.md
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "Boxento $TAG" \
+              --notes-file release-notes.md \
+              --latest
+          else
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "Boxento $TAG" \
+              --notes-file release-notes.md \
+              --latest
+          fi
+
+      - name: Write release summary
+        run: |
+          {
+            echo "## Boxento ${{ steps.release.outputs.tag }}"
+            echo
+            echo "- GitHub Release published"
+            echo "- Docker tags published: ${{ steps.meta.outputs.tags }}"
+            echo "- Hosted boxento.app deployment is intentionally not part of this workflow"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,18 @@ jobs:
           fi
 
           VERSION="${TAG#v}"
-          PREVIOUS_TAG="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -n 1 || true)"
+          git fetch --force --tags origin
+          git fetch --no-tags origin main:refs/remotes/origin/main
+
+          MAIN_SHA="$(git rev-parse origin/main)"
+          if [[ "$GITHUB_SHA" != "$MAIN_SHA" ]]; then
+            echo "Release tag $TAG must point at current origin/main." >&2
+            echo "Tag commit:  $GITHUB_SHA" >&2
+            echo "origin/main: $MAIN_SHA" >&2
+            exit 1
+          fi
+
+          PREVIOUS_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | awk -v tag="$TAG" '$0 == tag { print previous; exit } { previous = $0 }')"
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/docs/RELEASE_MANAGEMENT.md
+++ b/docs/RELEASE_MANAGEMENT.md
@@ -1,0 +1,106 @@
+# Release Management
+
+Boxento releases are tag-driven. A `vMAJOR.MINOR.PATCH` tag is the source of truth for public GitHub Releases and Docker images.
+
+Hosted deployment to `boxento.app` is intentionally excluded from the automated release workflow until Firebase deploy credentials are configured safely in GitHub Actions.
+
+## What Runs Where
+
+### Pull Requests
+
+Pull requests run tests and Docker build validation. They do not publish images or releases.
+
+### Main
+
+Merges to `main` publish development Docker images:
+
+- `ghcr.io/sushaantu/boxento:main`
+- `ghcr.io/sushaantu/boxento:sha-<commit>`
+
+`latest` is not published from every `main` merge.
+
+### Release Tags
+
+Pushing a tag like `v1.1.0` runs the release workflow:
+
+- installs dependencies
+- runs lint
+- runs unit tests
+- runs browser smoke tests
+- builds the app
+- publishes multi-architecture Docker images
+- creates or updates the GitHub Release
+- marks the GitHub Release as latest
+
+Docker tags published from `v1.1.0`:
+
+- `ghcr.io/sushaantu/boxento:1.1.0`
+- `ghcr.io/sushaantu/boxento:1.1`
+- `ghcr.io/sushaantu/boxento:1`
+- `ghcr.io/sushaantu/boxento:latest`
+- `ghcr.io/sushaantu/boxento:sha-<commit>`
+
+## Release Checklist
+
+1. Merge all intended release PRs into `main`.
+2. Update `CHANGELOG.md` in a PR when the release needs hand-written notes.
+3. Confirm `main` checks are green.
+4. Create and push an annotated tag:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v1.1.0 -m "Boxento v1.1.0"
+git push origin v1.1.0
+```
+
+5. Watch the `Release` workflow.
+6. Confirm the GitHub Release is marked latest.
+7. Confirm Docker users can pull:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+## Version Guidance
+
+- Patch: bug fix or compatibility fix, for example `v1.1.1`.
+- Minor: new widgets, substantial widget UX improvements, performance work, or new user-facing capabilities, for example `v1.2.0`.
+- Major: breaking configuration, storage, or deployment changes, for example `v2.0.0`.
+
+## Public Repo Safety
+
+Never commit secrets or private deploy credentials.
+
+Safe to commit:
+
+- workflow files
+- release scripts
+- documentation
+- references to GitHub secret names
+
+Do not commit:
+
+- `.env`
+- Firebase service account JSON
+- API tokens
+- private keys
+- production-only credentials
+
+## Rollback
+
+For Docker users, pin the previous version in `docker-compose.yml`:
+
+```yaml
+image: ghcr.io/sushaantu/boxento:1.1.0
+```
+
+Then run:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+If a GitHub Release was published with incorrect notes, edit the release notes rather than deleting the tag. Delete and recreate a tag only when the release artifact itself is wrong and users have not adopted it yet.

--- a/docs/RELEASE_MANAGEMENT.md
+++ b/docs/RELEASE_MANAGEMENT.md
@@ -103,4 +103,4 @@ docker compose pull
 docker compose up -d
 ```
 
-If a GitHub Release was published with incorrect notes, edit the release notes rather than deleting the tag. Delete and recreate a tag only when the release artifact itself is wrong and users have not adopted it yet.
+If a GitHub Release was published with incorrect notes, edit the release notes rather than deleting the tag. If the release artifact itself is wrong, publish a new patch version, for example `v1.1.1`, instead of deleting and recreating an existing public tag.


### PR DESCRIPTION
## Summary
Adds a tag-driven release path for Boxento that intentionally excludes boxento.app/Firebase deploy for now. A vMAJOR.MINOR.PATCH tag becomes the source of truth for GitHub Releases and Docker release images.

## What Changed
- Added a Release workflow that runs lint, unit tests, browser smoke tests, build, Docker multi-arch publish, and GitHub Release creation/update from v*.*.* tags.
- Changed the existing Docker workflow so main publishes only development images (:main and :sha-*); :latest and semver tags now come only from release tags.
- Added release management docs with the release checklist, Docker tag contract, public-repo safety notes, and rollback guidance.

## How to Test
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/docker-publish.yml .github/workflows/test.yml .github/workflows/release.yml
- git diff --check
- bun install --frozen-lockfile
- bun run lint
- bun run test
- bun run build

## Risks / Rollout Notes
- After this merges, Docker :latest stops updating on every main merge and becomes release-only. That is intentional so Docker users, GitHub Releases, and tags stop drifting.
- The workflow does not deploy boxento.app and does not require Firebase secrets.
- The first real use should be a v1.1.0 tag from a clean, green main branch.

## Review Focus
- Verify the Docker tag split between main and release tags.
- Verify GitHub Release notes generation is acceptable for a public OSS project.
- Verify no private credentials or Firebase deploy assumptions are introduced.

## PM Notes
This makes releases easier to trust publicly: a release tag now updates GitHub Releases and Docker images together. Hosted deployment remains manual/out of scope until Firebase deploy credentials are configured safely.