### PR TITLE
Add Home Assistant widget category

### DIFF
--- a/src/components/widgets/HomeClimateWidget/index.tsx
+++ b/src/components/widgets/HomeClimateWidget/index.tsx
@@ -17,7 +17,10 @@ import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
 import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
 import {
   CLIMATE_DOMAINS,
+  formatTemperatureValue,
   getClimateTemperature,
+  getTemperatureUnit,
+  isTemperatureEntity,
   selectEntities,
   toPersistedHomeAssistantConfig,
 } from '../homeAssistant/utils';
@@ -66,13 +69,17 @@ const HomeClimateWidget: React.FC<HomeClimateWidgetProps> = ({ width, height, co
     return [...direct, ...sensors];
   }, [appliedConfig.areaId, appliedConfig.entityIds, snapshot]);
 
-  const temperatures = climateEntities
-    .filter((entity) => entity.domain !== 'sensor' || entity.deviceClass === 'temperature')
+  const temperatureEntities = climateEntities.filter(isTemperatureEntity);
+  const temperatures = temperatureEntities
     .map(getClimateTemperature)
     .filter((value): value is number => typeof value === 'number');
   const averageTemperature = temperatures.length
     ? Math.round(temperatures.reduce((sum, value) => sum + value, 0) / temperatures.length)
     : null;
+  const temperatureUnit = temperatureEntities.map(getTemperatureUnit).find(Boolean);
+  const averageTemperatureLabel = averageTemperature != null
+    ? formatTemperatureValue(averageTemperature, temperatureUnit)
+    : 'n/a';
   const visibleEntities = climateEntities.slice(0, isApp ? 18 : appliedConfig.maxItems || 8);
 
   const resetSettings = () => {
@@ -92,13 +99,13 @@ const HomeClimateWidget: React.FC<HomeClimateWidgetProps> = ({ width, height, co
     if (!visibleEntities.length) return <HomeEmptyState label="No climate devices found" />;
 
     if (isTiny) {
-      return <HomeTinyStatus value={averageTemperature != null ? `${averageTemperature}C` : visibleEntities.length} label="Climate" />;
+      return <HomeTinyStatus value={averageTemperature != null ? averageTemperatureLabel : visibleEntities.length} label="Climate" />;
     }
 
     if (isShort) {
       return (
         <div className="flex h-full min-h-0 items-center gap-2 p-2">
-          <HomeMetricTile compact label="Average" value={averageTemperature != null ? `${averageTemperature}C` : 'n/a'} />
+          <HomeMetricTile compact label="Average" value={averageTemperatureLabel} />
           <HomeMetricTile compact label="Devices" value={climateEntities.length} />
           <HomeRefreshingBadge refreshing={refreshing} />
         </div>
@@ -108,7 +115,7 @@ const HomeClimateWidget: React.FC<HomeClimateWidgetProps> = ({ width, height, co
     return (
       <div className="flex h-full min-h-0 flex-col gap-3 p-3">
         <div className="flex items-center justify-between gap-2">
-          <HomeMetricTile label="Average Temperature" value={averageTemperature != null ? `${averageTemperature}C` : 'n/a'} />
+          <HomeMetricTile label="Average Temperature" value={averageTemperatureLabel} />
           <Thermometer className="size-5 text-muted-foreground" aria-hidden="true" />
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto">

--- a/src/components/widgets/HomeClimateWidget/index.tsx
+++ b/src/components/widgets/HomeClimateWidget/index.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { RefreshCw, Thermometer } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { WidgetShell } from '../common/WidgetShell';
+import {
+  HomeEmptyState,
+  HomeEntityRow,
+  HomeErrorState,
+  HomeLoadingState,
+  HomeMetricTile,
+  HomeRefreshingBadge,
+  HomeSetupState,
+  HomeTinyStatus,
+} from '../homeAssistant/components';
+import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
+import {
+  CLIMATE_DOMAINS,
+  getClimateTemperature,
+  selectEntities,
+  toPersistedHomeAssistantConfig,
+} from '../homeAssistant/utils';
+import type { HomeClimateWidgetConfig, HomeClimateWidgetProps } from './types';
+
+const DEFAULT_CONFIG: HomeClimateWidgetConfig = {
+  title: 'Climate',
+  baseUrl: '',
+  apiToken: '',
+  refreshInterval: 30,
+  areaId: '',
+  entityIds: [],
+  maxItems: 8,
+};
+
+const CLIMATE_SENSOR_CLASSES = new Set(['temperature', 'humidity']);
+
+const HomeClimateWidget: React.FC<HomeClimateWidgetProps> = ({ width, height, config }) => {
+  const isTiny = width === 1 && height === 1;
+  const isShort = height === 1 && width > 1;
+  const isCompact = width <= 2 || height <= 2;
+  const isApp = width >= 6 && height >= 6;
+  const readOnly = config?.readOnly ?? false;
+
+  const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
+  const [draftConfig, setDraftConfig] = useState<HomeClimateWidgetConfig>(appliedConfig);
+  const [showSettings, setShowSettings] = useState(false);
+  const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+
+  useEffect(() => {
+    setDraftConfig(appliedConfig);
+  }, [appliedConfig]);
+
+  const climateEntities = useMemo(() => {
+    const direct = selectEntities(snapshot, {
+      domains: CLIMATE_DOMAINS,
+      areaId: appliedConfig.areaId,
+      entityIds: appliedConfig.entityIds,
+    });
+    const sensors = selectEntities(snapshot, {
+      domains: ['sensor'],
+      areaId: appliedConfig.areaId,
+      entityIds: appliedConfig.entityIds,
+    }).filter((entity) => entity.deviceClass && CLIMATE_SENSOR_CLASSES.has(entity.deviceClass));
+
+    return [...direct, ...sensors];
+  }, [appliedConfig.areaId, appliedConfig.entityIds, snapshot]);
+
+  const temperatures = climateEntities
+    .filter((entity) => entity.domain !== 'sensor' || entity.deviceClass === 'temperature')
+    .map(getClimateTemperature)
+    .filter((value): value is number => typeof value === 'number');
+  const averageTemperature = temperatures.length
+    ? Math.round(temperatures.reduce((sum, value) => sum + value, 0) / temperatures.length)
+    : null;
+  const visibleEntities = climateEntities.slice(0, isApp ? 18 : appliedConfig.maxItems || 8);
+
+  const resetSettings = () => {
+    setDraftConfig(appliedConfig);
+    setShowSettings(false);
+  };
+
+  const saveSettings = () => {
+    config?.onUpdate?.(toPersistedHomeAssistantConfig(draftConfig));
+    setShowSettings(false);
+  };
+
+  const renderContent = () => {
+    if (!canFetch) return <HomeSetupState readOnly={readOnly} onSettingsClick={() => setShowSettings(true)} />;
+    if (loading) return <HomeLoadingState compact={isCompact} />;
+    if (error) return <HomeErrorState message={error} onRetry={refresh} />;
+    if (!visibleEntities.length) return <HomeEmptyState label="No climate devices found" />;
+
+    if (isTiny) {
+      return <HomeTinyStatus value={averageTemperature != null ? `${averageTemperature}C` : visibleEntities.length} label="Climate" />;
+    }
+
+    if (isShort) {
+      return (
+        <div className="flex h-full min-h-0 items-center gap-2 p-2">
+          <HomeMetricTile compact label="Average" value={averageTemperature != null ? `${averageTemperature}C` : 'n/a'} />
+          <HomeMetricTile compact label="Devices" value={climateEntities.length} />
+          <HomeRefreshingBadge refreshing={refreshing} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <HomeMetricTile label="Average Temperature" value={averageTemperature != null ? `${averageTemperature}C` : 'n/a'} />
+          <Thermometer className="size-5 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {visibleEntities.map((entity) => (
+            <HomeEntityRow key={entity.entityId} entity={entity} dense={isCompact} />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <WidgetShell
+      title={appliedConfig.title || DEFAULT_CONFIG.title}
+      isTiny={isTiny}
+      hideHeader={isApp}
+      compactHeader={isShort}
+      onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
+      contentClassName={isTiny ? 'p-1' : ''}
+      headerActions={!isTiny && !isApp ? (
+        <Button type="button" variant="ghost" size="icon" className="size-8 text-muted-foreground" onClick={(event) => {
+          event.stopPropagation();
+          refresh();
+        }} aria-label="Refresh climate">
+          <RefreshCw className="size-4" />
+        </Button>
+      ) : undefined}
+    >
+      {renderContent()}
+      {!readOnly ? (
+        <HomeAssistantSettingsDialog
+          open={showSettings}
+          title="Climate Settings"
+          config={draftConfig}
+          areas={snapshot?.areas}
+          showArea
+          showEntityIds
+          entityHelp="Optional. Include climate entities or temperature and humidity sensors."
+          onConfigChange={setDraftConfig}
+          onOpenChange={setShowSettings}
+          onCancel={resetSettings}
+          onSave={saveSettings}
+          onDelete={config?.onDelete}
+        />
+      ) : null}
+    </WidgetShell>
+  );
+};
+
+export default HomeClimateWidget;

--- a/src/components/widgets/HomeClimateWidget/types.ts
+++ b/src/components/widgets/HomeClimateWidget/types.ts
@@ -1,0 +1,8 @@
+import type { WidgetProps } from '@/types';
+import type { HomeAssistantBaseConfig } from '../homeAssistant/types';
+
+export interface HomeClimateWidgetConfig extends HomeAssistantBaseConfig {
+  maxItems?: number;
+}
+
+export type HomeClimateWidgetProps = WidgetProps<HomeClimateWidgetConfig>;

--- a/src/components/widgets/HomeDeviceHealthWidget/index.tsx
+++ b/src/components/widgets/HomeDeviceHealthWidget/index.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, BatteryWarning, CheckCircle2, Download, RefreshCw, WifiOff } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { WidgetShell } from '../common/WidgetShell';
+import {
+  HomeEmptyState,
+  HomeErrorState,
+  HomeLoadingState,
+  HomeMetricTile,
+  HomeRefreshingBadge,
+  HomeSetupState,
+  HomeTinyStatus,
+} from '../homeAssistant/components';
+import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
+import {
+  formatRelativeTime,
+  getHealthIssues,
+  toPersistedHomeAssistantConfig,
+} from '../homeAssistant/utils';
+import type { HomeAssistantHealthIssue } from '../homeAssistant/types';
+import type { HomeDeviceHealthWidgetConfig, HomeDeviceHealthWidgetProps } from './types';
+
+const DEFAULT_CONFIG: HomeDeviceHealthWidgetConfig = {
+  title: 'Device Health',
+  baseUrl: '',
+  apiToken: '',
+  refreshInterval: 30,
+  areaId: '',
+  entityIds: [],
+  batteryThreshold: 20,
+};
+
+const HomeDeviceHealthWidget: React.FC<HomeDeviceHealthWidgetProps> = ({ width, height, config }) => {
+  const isTiny = width === 1 && height === 1;
+  const isShort = height === 1 && width > 1;
+  const isCompact = width <= 2 || height <= 2;
+  const isApp = width >= 6 && height >= 6;
+  const readOnly = config?.readOnly ?? false;
+
+  const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
+  const [draftConfig, setDraftConfig] = useState<HomeDeviceHealthWidgetConfig>(appliedConfig);
+  const [showSettings, setShowSettings] = useState(false);
+  const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+
+  useEffect(() => {
+    setDraftConfig(appliedConfig);
+  }, [appliedConfig]);
+
+  const issues = useMemo(() => (
+    getHealthIssues(snapshot, appliedConfig.batteryThreshold)
+      .filter((issue) => !appliedConfig.areaId || issue.entity.areaId === appliedConfig.areaId)
+      .filter((issue) => !appliedConfig.entityIds?.length || appliedConfig.entityIds.includes(issue.entity.entityId))
+  ), [appliedConfig.areaId, appliedConfig.batteryThreshold, appliedConfig.entityIds, snapshot]);
+
+  const unavailableCount = issues.filter((issue) => issue.kind === 'unavailable').length;
+  const batteryCount = issues.filter((issue) => issue.kind === 'battery').length;
+  const updateCount = issues.filter((issue) => issue.kind === 'update').length;
+  const visibleIssues = issues.slice(0, isApp ? 24 : 8);
+
+  const resetSettings = () => {
+    setDraftConfig(appliedConfig);
+    setShowSettings(false);
+  };
+
+  const saveSettings = () => {
+    config?.onUpdate?.(toPersistedHomeAssistantConfig(draftConfig));
+    setShowSettings(false);
+  };
+
+  const renderContent = () => {
+    if (!canFetch) return <HomeSetupState readOnly={readOnly} onSettingsClick={() => setShowSettings(true)} />;
+    if (loading) return <HomeLoadingState compact={isCompact} />;
+    if (error) return <HomeErrorState message={error} onRetry={refresh} />;
+
+    if (isTiny) {
+      return <HomeTinyStatus value={issues.length || 'OK'} label={issues.length ? 'Issues' : 'Health'} tone={issues.length ? 'danger' : 'good'} />;
+    }
+
+    if (isShort) {
+      return (
+        <div className="flex h-full min-h-0 items-center gap-2 p-2">
+          <HomeMetricTile compact label="Offline" value={unavailableCount} tone={unavailableCount ? 'danger' : 'good'} />
+          <HomeMetricTile compact label="Battery" value={batteryCount} tone={batteryCount ? 'warning' : 'good'} />
+          <HomeMetricTile compact label="Updates" value={updateCount} />
+          <HomeRefreshingBadge refreshing={refreshing} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+        <div className="grid grid-cols-3 gap-2">
+          <HomeMetricTile compact label="Offline" value={unavailableCount} tone={unavailableCount ? 'danger' : 'good'} />
+          <HomeMetricTile compact label="Battery" value={batteryCount} tone={batteryCount ? 'warning' : 'good'} />
+          <HomeMetricTile compact label="Updates" value={updateCount} />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {visibleIssues.length ? (
+            visibleIssues.map((issue) => <IssueRow key={`${issue.kind}-${issue.entity.entityId}`} issue={issue} dense={isCompact} />)
+          ) : (
+            <HomeEmptyState label="All devices look healthy" />
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <WidgetShell
+      title={appliedConfig.title || DEFAULT_CONFIG.title}
+      isTiny={isTiny}
+      hideHeader={isApp}
+      compactHeader={isShort}
+      onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
+      contentClassName={isTiny ? 'p-1' : ''}
+      headerActions={!isTiny && !isApp ? (
+        <Button type="button" variant="ghost" size="icon" className="size-8 text-muted-foreground" onClick={(event) => {
+          event.stopPropagation();
+          refresh();
+        }} aria-label="Refresh device health">
+          <RefreshCw className="size-4" />
+        </Button>
+      ) : undefined}
+    >
+      {renderContent()}
+      {!readOnly ? (
+        <HomeAssistantSettingsDialog
+          open={showSettings}
+          title="Device Health Settings"
+          config={draftConfig}
+          areas={snapshot?.areas}
+          showArea
+          showEntityIds
+          entityHelp="Optional. Leave empty to monitor all matching health signals."
+          onConfigChange={setDraftConfig}
+          onOpenChange={setShowSettings}
+          onCancel={resetSettings}
+          onSave={saveSettings}
+          onDelete={config?.onDelete}
+        >
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="ha-battery-threshold">Low Battery Threshold</Label>
+            <Input
+              id="ha-battery-threshold"
+              type="number"
+              min={1}
+              max={100}
+              value={String(draftConfig.batteryThreshold || 20)}
+              onChange={(event) => setDraftConfig((current) => ({
+                ...current,
+                batteryThreshold: Number(event.target.value) || 20,
+              }))}
+            />
+          </div>
+        </HomeAssistantSettingsDialog>
+      ) : null}
+    </WidgetShell>
+  );
+};
+
+function IssueRow({ issue, dense }: { issue: HomeAssistantHealthIssue; dense: boolean }) {
+  const Icon = issue.kind === 'battery'
+    ? BatteryWarning
+    : issue.kind === 'update'
+      ? Download
+      : WifiOff;
+
+  return (
+    <div className="flex min-w-0 items-center gap-2 rounded-md px-2 py-2 hover:bg-muted/60">
+      <Icon className={issue.severity === 'critical' ? 'size-4 shrink-0 text-destructive' : 'size-4 shrink-0 text-yellow-600 dark:text-yellow-300'} aria-hidden="true" />
+      <div className="min-w-0 flex-1">
+        <div className={dense ? 'truncate text-xs font-medium text-foreground' : 'truncate text-sm font-medium text-foreground'}>
+          {issue.entity.name}
+        </div>
+        <div className="truncate text-[11px] text-muted-foreground">
+          {issue.label} · {formatRelativeTime(issue.entity.lastChanged)}
+        </div>
+      </div>
+      {issue.severity === 'critical' ? (
+        <AlertTriangle className="size-4 shrink-0 text-destructive" aria-hidden="true" />
+      ) : (
+        <CheckCircle2 className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      )}
+    </div>
+  );
+}
+
+export default HomeDeviceHealthWidget;

--- a/src/components/widgets/HomeDeviceHealthWidget/types.ts
+++ b/src/components/widgets/HomeDeviceHealthWidget/types.ts
@@ -1,0 +1,8 @@
+import type { WidgetProps } from '@/types';
+import type { HomeAssistantBaseConfig } from '../homeAssistant/types';
+
+export interface HomeDeviceHealthWidgetConfig extends HomeAssistantBaseConfig {
+  batteryThreshold?: number;
+}
+
+export type HomeDeviceHealthWidgetProps = WidgetProps<HomeDeviceHealthWidgetConfig>;

--- a/src/components/widgets/HomeLightsWidget/index.tsx
+++ b/src/components/widgets/HomeLightsWidget/index.tsx
@@ -1,0 +1,193 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Lightbulb, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { WidgetShell } from '../common/WidgetShell';
+import { callHomeAssistantService } from '../homeAssistant/client';
+import {
+  HomeEmptyState,
+  HomeEntityRow,
+  HomeErrorState,
+  HomeLoadingState,
+  HomeMetricTile,
+  HomeRefreshingBadge,
+  HomeSetupState,
+  HomeTinyStatus,
+} from '../homeAssistant/components';
+import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
+import {
+  LIGHT_DOMAINS,
+  isEntityOn,
+  selectEntities,
+  toPersistedHomeAssistantConfig,
+} from '../homeAssistant/utils';
+import type { HomeAssistantEntity } from '../homeAssistant/types';
+import type { HomeLightsWidgetConfig, HomeLightsWidgetProps } from './types';
+
+const DEFAULT_CONFIG: HomeLightsWidgetConfig = {
+  title: 'Lights',
+  baseUrl: '',
+  apiToken: '',
+  refreshInterval: 30,
+  areaId: '',
+  entityIds: [],
+  maxItems: 10,
+  showOnlyOn: false,
+};
+
+const HomeLightsWidget: React.FC<HomeLightsWidgetProps> = ({ width, height, config }) => {
+  const isTiny = width === 1 && height === 1;
+  const isShort = height === 1 && width > 1;
+  const isCompact = width <= 2 || height <= 2;
+  const isApp = width >= 6 && height >= 6;
+  const readOnly = config?.readOnly ?? false;
+
+  const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
+  const [draftConfig, setDraftConfig] = useState<HomeLightsWidgetConfig>(appliedConfig);
+  const [showSettings, setShowSettings] = useState(false);
+  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
+  const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+
+  useEffect(() => {
+    setDraftConfig(appliedConfig);
+  }, [appliedConfig]);
+
+  const lights = useMemo(() => {
+    const selected = selectEntities(snapshot, {
+      domains: LIGHT_DOMAINS,
+      areaId: appliedConfig.areaId,
+      entityIds: appliedConfig.entityIds,
+    });
+
+    return appliedConfig.showOnlyOn ? selected.filter(isEntityOn) : selected;
+  }, [appliedConfig.areaId, appliedConfig.entityIds, appliedConfig.showOnlyOn, snapshot]);
+
+  const onCount = lights.filter(isEntityOn).length;
+  const visibleLights = lights.slice(0, isApp ? 24 : appliedConfig.maxItems || 10);
+
+  const toggleLight = useCallback(async (entity: HomeAssistantEntity) => {
+    if (readOnly) return;
+
+    try {
+      setPendingEntityId(entity.entityId);
+      await callHomeAssistantService(appliedConfig, 'light', 'toggle', entity.entityId);
+      await refresh();
+    } finally {
+      setPendingEntityId(null);
+    }
+  }, [appliedConfig, readOnly, refresh]);
+
+  const resetSettings = () => {
+    setDraftConfig(appliedConfig);
+    setShowSettings(false);
+  };
+
+  const saveSettings = () => {
+    config?.onUpdate?.(toPersistedHomeAssistantConfig(draftConfig));
+    setShowSettings(false);
+  };
+
+  const renderContent = () => {
+    if (!canFetch) return <HomeSetupState readOnly={readOnly} onSettingsClick={() => setShowSettings(true)} />;
+    if (loading) return <HomeLoadingState compact={isCompact} />;
+    if (error) return <HomeErrorState message={error} onRetry={refresh} />;
+    if (!visibleLights.length) return <HomeEmptyState label="No lights found" />;
+
+    if (isTiny) {
+      return <HomeTinyStatus value={onCount} label="Lights on" tone={onCount ? 'good' : 'neutral'} />;
+    }
+
+    if (isShort) {
+      return (
+        <div className="flex h-full min-h-0 items-center gap-2 overflow-hidden p-2">
+          <HomeMetricTile compact label="On" value={`${onCount}/${lights.length}`} />
+          {visibleLights.slice(0, 3).map((light) => (
+            <Button
+              key={light.entityId}
+              type="button"
+              size="sm"
+              variant={isEntityOn(light) ? 'default' : 'outline'}
+              disabled={readOnly || pendingEntityId === light.entityId}
+              onClick={() => toggleLight(light)}
+              className="h-8 min-w-0 shrink truncate px-2 text-xs"
+            >
+              {light.name}
+            </Button>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <HomeMetricTile compact label="Lights On" value={`${onCount}/${lights.length}`} tone={onCount ? 'good' : 'neutral'} />
+          <Lightbulb className="size-5 text-muted-foreground" aria-hidden="true" />
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {visibleLights.map((light) => (
+            <HomeEntityRow
+              key={light.entityId}
+              entity={light}
+              dense={isCompact}
+              action={readOnly ? undefined : () => toggleLight(light)}
+              actionDisabled={pendingEntityId === light.entityId}
+            />
+          ))}
+        </div>
+        <HomeRefreshingBadge refreshing={refreshing} />
+      </div>
+    );
+  };
+
+  return (
+    <WidgetShell
+      title={appliedConfig.title || DEFAULT_CONFIG.title}
+      isTiny={isTiny}
+      hideHeader={isApp}
+      compactHeader={isShort}
+      onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
+      contentClassName={isTiny ? 'p-1' : ''}
+      headerActions={!isTiny && !isApp ? (
+        <Button type="button" variant="ghost" size="icon" className="size-8 text-muted-foreground" onClick={(event) => {
+          event.stopPropagation();
+          refresh();
+        }} aria-label="Refresh lights">
+          <RefreshCw className="size-4" />
+        </Button>
+      ) : undefined}
+    >
+      {renderContent()}
+      {!readOnly ? (
+        <HomeAssistantSettingsDialog
+          open={showSettings}
+          title="Lights Settings"
+          config={draftConfig}
+          areas={snapshot?.areas}
+          showArea
+          showEntityIds
+          entityHelp="Optional. Leave empty to show all lights in the selected room."
+          onConfigChange={setDraftConfig}
+          onOpenChange={setShowSettings}
+          onCancel={resetSettings}
+          onSave={saveSettings}
+          onDelete={config?.onDelete}
+        >
+          <div className="flex items-center justify-between rounded-md border border-border px-3 py-2">
+            <Label htmlFor="ha-lights-only-on">Only show lights that are on</Label>
+            <Switch
+              id="ha-lights-only-on"
+              checked={!!draftConfig.showOnlyOn}
+              onCheckedChange={(checked) => setDraftConfig((current) => ({ ...current, showOnlyOn: checked }))}
+            />
+          </div>
+        </HomeAssistantSettingsDialog>
+      ) : null}
+    </WidgetShell>
+  );
+};
+
+export default HomeLightsWidget;

--- a/src/components/widgets/HomeLightsWidget/types.ts
+++ b/src/components/widgets/HomeLightsWidget/types.ts
@@ -1,0 +1,9 @@
+import type { WidgetProps } from '@/types';
+import type { HomeAssistantBaseConfig } from '../homeAssistant/types';
+
+export interface HomeLightsWidgetConfig extends HomeAssistantBaseConfig {
+  maxItems?: number;
+  showOnlyOn?: boolean;
+}
+
+export type HomeLightsWidgetProps = WidgetProps<HomeLightsWidgetConfig>;

--- a/src/components/widgets/HomeOverviewWidget/index.tsx
+++ b/src/components/widgets/HomeOverviewWidget/index.tsx
@@ -1,0 +1,178 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, Home, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { WidgetShell } from '../common/WidgetShell';
+import {
+  HomeEmptyState,
+  HomeErrorState,
+  HomeLoadingState,
+  HomeMetricTile,
+  HomeRefreshingBadge,
+  HomeSetupState,
+  HomeTinyStatus,
+} from '../homeAssistant/components';
+import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
+import {
+  getHealthIssues,
+  isEntityOn,
+  selectEntities,
+  toPersistedHomeAssistantConfig,
+} from '../homeAssistant/utils';
+import type { HomeOverviewWidgetConfig, HomeOverviewWidgetProps } from './types';
+
+const DEFAULT_CONFIG: HomeOverviewWidgetConfig = {
+  title: 'Home Overview',
+  baseUrl: '',
+  apiToken: '',
+  refreshInterval: 30,
+  batteryThreshold: 20,
+};
+
+const HomeOverviewWidget: React.FC<HomeOverviewWidgetProps> = ({ width, height, config }) => {
+  const isTiny = width === 1 && height === 1;
+  const isShort = height === 1 && width > 1;
+  const isCompact = width <= 2 || height <= 2;
+  const isApp = width >= 6 && height >= 6;
+  const readOnly = config?.readOnly ?? false;
+
+  const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
+  const [draftConfig, setDraftConfig] = useState<HomeOverviewWidgetConfig>(appliedConfig);
+  const [showSettings, setShowSettings] = useState(false);
+  const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+
+  useEffect(() => {
+    setDraftConfig(appliedConfig);
+  }, [appliedConfig]);
+
+  const summary = useMemo(() => {
+    const lights = selectEntities(snapshot, { domains: ['light'] });
+    const climate = selectEntities(snapshot, { domains: ['climate'] });
+    const security = selectEntities(snapshot, { domains: ['lock', 'cover', 'binary_sensor', 'alarm_control_panel'] });
+    const issues = getHealthIssues(snapshot, appliedConfig.batteryThreshold);
+    const doorsOpen = security.filter((entity) => ['open', 'unlocked', 'triggered'].includes(entity.state)).length;
+
+    return {
+      lightsOn: lights.filter(isEntityOn).length,
+      lightCount: lights.length,
+      climateCount: climate.length,
+      doorsOpen,
+      issueCount: issues.length,
+      issues: issues.slice(0, isApp ? 12 : 5),
+      entityCount: snapshot?.entities.length || 0,
+    };
+  }, [appliedConfig.batteryThreshold, isApp, snapshot]);
+
+  const resetSettings = () => {
+    setDraftConfig(appliedConfig);
+    setShowSettings(false);
+  };
+
+  const saveSettings = () => {
+    config?.onUpdate?.(toPersistedHomeAssistantConfig(draftConfig));
+    setShowSettings(false);
+  };
+
+  const renderContent = () => {
+    if (!canFetch) {
+      return <HomeSetupState readOnly={readOnly} onSettingsClick={() => setShowSettings(true)} />;
+    }
+
+    if (loading) return <HomeLoadingState compact={isCompact} />;
+    if (error) return <HomeErrorState message={error} onRetry={refresh} />;
+    if (!snapshot || summary.entityCount === 0) return <HomeEmptyState label="No Home Assistant entities" />;
+
+    if (isTiny) {
+      return (
+        <HomeTinyStatus
+          value={summary.issueCount || 'OK'}
+          label={summary.issueCount ? 'Issues' : 'Home'}
+          tone={summary.issueCount ? 'danger' : 'good'}
+        />
+      );
+    }
+
+    if (isShort) {
+      return (
+        <div className="flex h-full min-h-0 items-center gap-2 p-2">
+          <HomeMetricTile compact label="Lights" value={`${summary.lightsOn}/${summary.lightCount}`} />
+          <HomeMetricTile compact label="Open" value={summary.doorsOpen} tone={summary.doorsOpen ? 'warning' : 'good'} />
+          <HomeMetricTile compact label="Issues" value={summary.issueCount} tone={summary.issueCount ? 'danger' : 'good'} />
+          <HomeRefreshingBadge refreshing={refreshing} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+        <div className="grid grid-cols-2 gap-2">
+          <HomeMetricTile label="Lights On" value={`${summary.lightsOn}/${summary.lightCount}`} />
+          <HomeMetricTile label="Climate" value={summary.climateCount} />
+          <HomeMetricTile label="Open / Unlocked" value={summary.doorsOpen} tone={summary.doorsOpen ? 'warning' : 'good'} />
+          <HomeMetricTile label="Health Issues" value={summary.issueCount} tone={summary.issueCount ? 'danger' : 'good'} />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <div className="mb-1 flex items-center justify-between">
+            <p className="text-xs font-medium text-muted-foreground">Needs attention</p>
+            <HomeRefreshingBadge refreshing={refreshing} />
+          </div>
+          {summary.issues.length ? (
+            <div className="flex h-full min-h-0 flex-col overflow-y-auto">
+              {summary.issues.map((issue) => (
+                <div key={`${issue.kind}-${issue.entity.entityId}`} className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm">
+                  <AlertTriangle className="size-4 shrink-0 text-destructive" aria-hidden="true" />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-foreground">{issue.entity.name}</div>
+                    <div className="truncate text-[11px] text-muted-foreground">{issue.label}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-full min-h-0 items-center gap-2 rounded-md bg-muted/40 px-3 text-sm text-muted-foreground">
+              <Home className="size-4" aria-hidden="true" />
+              Home looks normal
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <WidgetShell
+      title={appliedConfig.title || DEFAULT_CONFIG.title}
+      isTiny={isTiny}
+      hideHeader={isApp}
+      compactHeader={isShort}
+      onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
+      contentClassName={isTiny ? 'p-1' : ''}
+      headerActions={!isTiny && !isApp ? (
+        <Button type="button" variant="ghost" size="icon" className="size-8 text-muted-foreground" onClick={(event) => {
+          event.stopPropagation();
+          refresh();
+        }} aria-label="Refresh Home Assistant">
+          <RefreshCw className="size-4" />
+        </Button>
+      ) : undefined}
+    >
+      {renderContent()}
+      {!readOnly ? (
+        <HomeAssistantSettingsDialog
+          open={showSettings}
+          title="Home Overview Settings"
+          config={draftConfig}
+          onConfigChange={setDraftConfig}
+          onOpenChange={setShowSettings}
+          onCancel={resetSettings}
+          onSave={saveSettings}
+          onDelete={config?.onDelete}
+        />
+      ) : null}
+    </WidgetShell>
+  );
+};
+
+export default HomeOverviewWidget;

--- a/src/components/widgets/HomeOverviewWidget/index.tsx
+++ b/src/components/widgets/HomeOverviewWidget/index.tsx
@@ -16,6 +16,7 @@ import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
 import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
 import {
   getHealthIssues,
+  isActiveSecurityEntity,
   isEntityOn,
   selectEntities,
   toPersistedHomeAssistantConfig,
@@ -51,7 +52,7 @@ const HomeOverviewWidget: React.FC<HomeOverviewWidgetProps> = ({ width, height, 
     const climate = selectEntities(snapshot, { domains: ['climate'] });
     const security = selectEntities(snapshot, { domains: ['lock', 'cover', 'binary_sensor', 'alarm_control_panel'] });
     const issues = getHealthIssues(snapshot, appliedConfig.batteryThreshold);
-    const doorsOpen = security.filter((entity) => ['open', 'unlocked', 'triggered'].includes(entity.state)).length;
+    const doorsOpen = security.filter(isActiveSecurityEntity).length;
 
     return {
       lightsOn: lights.filter(isEntityOn).length,

--- a/src/components/widgets/HomeOverviewWidget/types.ts
+++ b/src/components/widgets/HomeOverviewWidget/types.ts
@@ -1,0 +1,8 @@
+import type { WidgetProps } from '@/types';
+import type { HomeAssistantBaseConfig } from '../homeAssistant/types';
+
+export interface HomeOverviewWidgetConfig extends HomeAssistantBaseConfig {
+  batteryThreshold?: number;
+}
+
+export type HomeOverviewWidgetProps = WidgetProps<HomeOverviewWidgetConfig>;

--- a/src/components/widgets/HomeRoomWidget/index.tsx
+++ b/src/components/widgets/HomeRoomWidget/index.tsx
@@ -1,0 +1,190 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { DoorOpen, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { WidgetShell } from '../common/WidgetShell';
+import { callHomeAssistantService } from '../homeAssistant/client';
+import {
+  HomeEmptyState,
+  HomeEntityRow,
+  HomeErrorState,
+  HomeLoadingState,
+  HomeMetricTile,
+  HomeRefreshingBadge,
+  HomeSetupState,
+  HomeTinyStatus,
+} from '../homeAssistant/components';
+import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
+import {
+  ROOM_DOMAINS,
+  canToggleEntity,
+  getAreaName,
+  getToggleService,
+  isEntityOn,
+  selectEntities,
+  toPersistedHomeAssistantConfig,
+} from '../homeAssistant/utils';
+import type { HomeAssistantEntity } from '../homeAssistant/types';
+import type { HomeRoomWidgetConfig, HomeRoomWidgetProps } from './types';
+
+const DEFAULT_CONFIG: HomeRoomWidgetConfig = {
+  title: 'Room Control',
+  baseUrl: '',
+  apiToken: '',
+  refreshInterval: 30,
+  areaId: '',
+  entityIds: [],
+  maxItems: 8,
+};
+
+const HomeRoomWidget: React.FC<HomeRoomWidgetProps> = ({ width, height, config }) => {
+  const isTiny = width === 1 && height === 1;
+  const isShort = height === 1 && width > 1;
+  const isCompact = width <= 2 || height <= 2;
+  const isApp = width >= 6 && height >= 6;
+  const readOnly = config?.readOnly ?? false;
+
+  const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
+  const [draftConfig, setDraftConfig] = useState<HomeRoomWidgetConfig>(appliedConfig);
+  const [showSettings, setShowSettings] = useState(false);
+  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
+  const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+
+  useEffect(() => {
+    setDraftConfig(appliedConfig);
+  }, [appliedConfig]);
+
+  const roomEntities = useMemo(() => {
+    const explicitAreaId = appliedConfig.areaId || inferPrimaryAreaId(snapshot);
+
+    return selectEntities(snapshot, {
+      domains: ROOM_DOMAINS,
+      areaId: explicitAreaId,
+      entityIds: appliedConfig.entityIds,
+    });
+  }, [appliedConfig.areaId, appliedConfig.entityIds, snapshot]);
+
+  const roomName = getAreaName(snapshot, appliedConfig.areaId || inferPrimaryAreaId(snapshot));
+  const visibleEntities = roomEntities.slice(0, isApp ? 18 : appliedConfig.maxItems || 8);
+  const activeCount = roomEntities.filter(isEntityOn).length;
+
+  const toggleEntity = useCallback(async (entity: HomeAssistantEntity) => {
+    const service = getToggleService(entity);
+    if (!service || readOnly) return;
+
+    try {
+      setPendingEntityId(entity.entityId);
+      await callHomeAssistantService(appliedConfig, service.domain, service.service, entity.entityId);
+      await refresh();
+    } finally {
+      setPendingEntityId(null);
+    }
+  }, [appliedConfig, readOnly, refresh]);
+
+  const resetSettings = () => {
+    setDraftConfig(appliedConfig);
+    setShowSettings(false);
+  };
+
+  const saveSettings = () => {
+    config?.onUpdate?.(toPersistedHomeAssistantConfig(draftConfig));
+    setShowSettings(false);
+  };
+
+  const renderContent = () => {
+    if (!canFetch) return <HomeSetupState readOnly={readOnly} onSettingsClick={() => setShowSettings(true)} />;
+    if (loading) return <HomeLoadingState compact={isCompact} />;
+    if (error) return <HomeErrorState message={error} onRetry={refresh} />;
+    if (!visibleEntities.length) return <HomeEmptyState label="No room devices found" />;
+
+    if (isTiny) {
+      return <HomeTinyStatus value={activeCount} label={roomName} tone={activeCount ? 'good' : 'neutral'} />;
+    }
+
+    if (isShort) {
+      return (
+        <div className="flex h-full min-h-0 items-center gap-2 p-2">
+          <HomeMetricTile compact label={roomName} value={`${activeCount} active`} />
+          <HomeMetricTile compact label="Devices" value={roomEntities.length} />
+          <HomeRefreshingBadge refreshing={refreshing} />
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-foreground">{roomName}</div>
+            <div className="text-xs text-muted-foreground">{activeCount} active of {roomEntities.length}</div>
+          </div>
+          <DoorOpen className="size-5 text-muted-foreground" aria-hidden="true" />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {visibleEntities.map((entity) => (
+            <HomeEntityRow
+              key={entity.entityId}
+              entity={entity}
+              dense={isCompact}
+              action={canToggleEntity(entity) && !readOnly ? () => toggleEntity(entity) : undefined}
+              actionDisabled={pendingEntityId === entity.entityId}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <WidgetShell
+      title={appliedConfig.title || DEFAULT_CONFIG.title}
+      isTiny={isTiny}
+      hideHeader={isApp}
+      compactHeader={isShort}
+      onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
+      contentClassName={isTiny ? 'p-1' : ''}
+      headerActions={!isTiny && !isApp ? (
+        <Button type="button" variant="ghost" size="icon" className="size-8 text-muted-foreground" onClick={(event) => {
+          event.stopPropagation();
+          refresh();
+        }} aria-label="Refresh room">
+          <RefreshCw className="size-4" />
+        </Button>
+      ) : undefined}
+    >
+      {renderContent()}
+      {!readOnly ? (
+        <HomeAssistantSettingsDialog
+          open={showSettings}
+          title="Room Control Settings"
+          config={draftConfig}
+          areas={snapshot?.areas}
+          showArea
+          showEntityIds
+          entityHelp="Optional. Leave empty to show the selected room."
+          onConfigChange={setDraftConfig}
+          onOpenChange={setShowSettings}
+          onCancel={resetSettings}
+          onSave={saveSettings}
+          onDelete={config?.onDelete}
+        />
+      ) : null}
+    </WidgetShell>
+  );
+};
+
+function inferPrimaryAreaId(snapshot: ReturnType<typeof useHomeAssistantData>['snapshot']): string {
+  if (!snapshot?.areas.length) return '';
+
+  const counts = new Map<string, number>();
+  for (const entity of snapshot.entities) {
+    if (!entity.areaId) continue;
+    counts.set(entity.areaId, (counts.get(entity.areaId) || 0) + 1);
+  }
+
+  return [...counts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] || snapshot.areas[0].area_id;
+}
+
+export default HomeRoomWidget;

--- a/src/components/widgets/HomeRoomWidget/types.ts
+++ b/src/components/widgets/HomeRoomWidget/types.ts
@@ -1,0 +1,8 @@
+import type { WidgetProps } from '@/types';
+import type { HomeAssistantBaseConfig } from '../homeAssistant/types';
+
+export interface HomeRoomWidgetConfig extends HomeAssistantBaseConfig {
+  maxItems?: number;
+}
+
+export type HomeRoomWidgetProps = WidgetProps<HomeRoomWidgetConfig>;

--- a/src/components/widgets/common/WidgetSelector.tsx
+++ b/src/components/widgets/common/WidgetSelector.tsx
@@ -1,5 +1,27 @@
 import React, { useState, useEffect } from 'react';
-import { X, Plus, Calendar, Cloud, Clock, Link, StickyNote, CheckSquare, Timer, DollarSign, BookOpen, Video, Rss, Github, Plane, Globe } from 'lucide-react';
+import {
+  X,
+  Plus,
+  Calendar,
+  Cloud,
+  Clock,
+  Link,
+  StickyNote,
+  CheckSquare,
+  Timer,
+  DollarSign,
+  BookOpen,
+  Video,
+  Rss,
+  Github,
+  Plane,
+  Globe,
+  Home,
+  DoorOpen,
+  Lightbulb,
+  Thermometer,
+  Activity,
+} from 'lucide-react';
 import { WidgetConfig } from '@/types';
 import { Button } from '@/components/ui/button';
 
@@ -45,6 +67,11 @@ const WidgetSelector = ({
       case 'Github': return <Github className="size-4" />;
       case 'Plane': return <Plane className="size-4" />;
       case 'Globe': return <Globe className="size-4" />;
+      case 'Home': return <Home className="size-4" />;
+      case 'DoorOpen': return <DoorOpen className="size-4" />;
+      case 'Lightbulb': return <Lightbulb className="size-4" />;
+      case 'Thermometer': return <Thermometer className="size-4" />;
+      case 'Activity': return <Activity className="size-4" />;
       default: return <Plus className="size-4" />;
     }
   };

--- a/src/components/widgets/homeAssistant/client.ts
+++ b/src/components/widgets/homeAssistant/client.ts
@@ -1,0 +1,200 @@
+import type {
+  HomeAssistantArea,
+  HomeAssistantConnectionConfig,
+  HomeAssistantDevice,
+  HomeAssistantEntityRegistryEntry,
+  HomeAssistantSnapshot,
+  HomeAssistantState,
+} from './types';
+import { buildHomeAssistantEntities } from './utils';
+
+type RegistryResults = {
+  areas: HomeAssistantArea[];
+  devices: HomeAssistantDevice[];
+  entities: HomeAssistantEntityRegistryEntry[];
+};
+
+const EMPTY_REGISTRY: RegistryResults = {
+  areas: [],
+  devices: [],
+  entities: [],
+};
+
+export function normalizeHomeAssistantUrl(value?: string): string {
+  const rawValue = (value || '').trim();
+  if (!rawValue) return '';
+
+  const withProtocol = /^https?:\/\//i.test(rawValue) ? rawValue : `http://${rawValue}`;
+
+  try {
+    const parsed = new URL(withProtocol);
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString().replace(/\/$/, '');
+  } catch {
+    return '';
+  }
+}
+
+export async function fetchHomeAssistantSnapshot(
+  config: HomeAssistantConnectionConfig,
+  signal?: AbortSignal
+): Promise<HomeAssistantSnapshot> {
+  const baseUrl = normalizeHomeAssistantUrl(config.baseUrl);
+  const token = config.apiToken?.trim();
+
+  if (!baseUrl || !token) {
+    throw new Error('Home Assistant connection is not configured');
+  }
+
+  const states = await homeAssistantFetch<HomeAssistantState[]>(baseUrl, token, '/api/states', {
+    signal,
+  });
+  const registry = await fetchRegistrySnapshot(baseUrl, token);
+  const entities = buildHomeAssistantEntities(states, registry);
+
+  return {
+    states,
+    areas: registry.areas,
+    devices: registry.devices,
+    registryEntities: registry.entities,
+    entities,
+    loadedAt: new Date().toISOString(),
+  };
+}
+
+export async function callHomeAssistantService(
+  config: HomeAssistantConnectionConfig,
+  domain: string,
+  service: string,
+  entityId: string
+): Promise<void> {
+  const baseUrl = normalizeHomeAssistantUrl(config.baseUrl);
+  const token = config.apiToken?.trim();
+
+  if (!baseUrl || !token) {
+    throw new Error('Home Assistant connection is not configured');
+  }
+
+  await homeAssistantFetch(baseUrl, token, `/api/services/${domain}/${service}`, {
+    method: 'POST',
+    body: JSON.stringify({ entity_id: entityId }),
+  });
+}
+
+async function homeAssistantFetch<T = unknown>(
+  baseUrl: string,
+  token: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error('Home Assistant rejected the access token');
+    }
+
+    throw new Error(`Home Assistant request failed (${response.status})`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function fetchRegistrySnapshot(baseUrl: string, token: string): Promise<RegistryResults> {
+  return new Promise((resolve) => {
+    let settled = false;
+    let nextId = 1;
+    const results: RegistryResults = { ...EMPTY_REGISTRY };
+    const pending = new Map<number, keyof RegistryResults>();
+    const ws = new WebSocket(createWebSocketUrl(baseUrl));
+
+    const finish = (value: RegistryResults) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      try {
+        ws.close();
+      } catch {
+        // The socket can already be closing.
+      }
+      resolve(value);
+    };
+
+    const sendRegistryRequest = (key: keyof RegistryResults, type: string) => {
+      const id = nextId;
+      nextId += 1;
+      pending.set(id, key);
+      ws.send(JSON.stringify({ id, type }));
+    };
+
+    const timeoutId = window.setTimeout(() => finish(EMPTY_REGISTRY), 3500);
+
+    ws.addEventListener('message', (event) => {
+      let message: Record<string, unknown>;
+      try {
+        message = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+
+      if (message.type === 'auth_required') {
+        ws.send(JSON.stringify({ type: 'auth', access_token: token }));
+        return;
+      }
+
+      if (message.type === 'auth_invalid') {
+        finish(EMPTY_REGISTRY);
+        return;
+      }
+
+      if (message.type === 'auth_ok') {
+        sendRegistryRequest('areas', 'config/area_registry/list');
+        sendRegistryRequest('devices', 'config/device_registry/list');
+        sendRegistryRequest('entities', 'config/entity_registry/list');
+        return;
+      }
+
+      if (message.type !== 'result' || typeof message.id !== 'number') {
+        return;
+      }
+
+      const key = pending.get(message.id);
+      if (!key) return;
+
+      pending.delete(message.id);
+      const result = Array.isArray(message.result) ? message.result : [];
+      results[key] = result as never;
+
+      if (pending.size === 0) {
+        finish(results);
+      }
+    });
+
+    ws.addEventListener('error', () => finish(EMPTY_REGISTRY));
+    ws.addEventListener('close', () => {
+      if (!settled) finish(EMPTY_REGISTRY);
+    });
+  });
+}
+
+function createWebSocketUrl(baseUrl: string): string {
+  const parsed = new URL(baseUrl);
+  parsed.protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+  parsed.pathname = `${parsed.pathname.replace(/\/+$/, '')}/api/websocket`;
+  parsed.search = '';
+  parsed.hash = '';
+  return parsed.toString();
+}

--- a/src/components/widgets/homeAssistant/client.ts
+++ b/src/components/widgets/homeAssistant/client.ts
@@ -20,6 +20,17 @@ const EMPTY_REGISTRY: RegistryResults = {
   entities: [],
 };
 
+type RegistryCacheEntry = {
+  expiresAt: number;
+  promise?: Promise<RegistryResults>;
+  value?: RegistryResults;
+};
+
+const REGISTRY_FETCH_TIMEOUT_MS = 8000;
+const REGISTRY_CACHE_TTL_MS = 30 * 60 * 1000;
+const EMPTY_REGISTRY_CACHE_TTL_MS = 60 * 1000;
+const registryCache = new Map<string, RegistryCacheEntry>();
+
 export function normalizeHomeAssistantUrl(value?: string): string {
   const rawValue = (value || '').trim();
   if (!rawValue) return '';
@@ -114,6 +125,39 @@ async function homeAssistantFetch<T = unknown>(
 }
 
 async function fetchRegistrySnapshot(baseUrl: string, token: string): Promise<RegistryResults> {
+  const now = Date.now();
+  const cached = registryCache.get(baseUrl);
+
+  if (cached?.value && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  if (cached?.promise) {
+    return cached.promise;
+  }
+
+  const promise = fetchRegistrySnapshotUncached(baseUrl, token)
+    .then((value) => {
+      registryCache.set(baseUrl, {
+        value,
+        expiresAt: Date.now() + getRegistryCacheDuration(value),
+      });
+      return value;
+    })
+    .catch((error) => {
+      registryCache.delete(baseUrl);
+      throw error;
+    });
+
+  registryCache.set(baseUrl, {
+    promise,
+    expiresAt: now + REGISTRY_FETCH_TIMEOUT_MS,
+  });
+
+  return promise;
+}
+
+function fetchRegistrySnapshotUncached(baseUrl: string, token: string): Promise<RegistryResults> {
   return new Promise((resolve) => {
     let settled = false;
     let nextId = 1;
@@ -140,7 +184,7 @@ async function fetchRegistrySnapshot(baseUrl: string, token: string): Promise<Re
       ws.send(JSON.stringify({ id, type }));
     };
 
-    const timeoutId = window.setTimeout(() => finish(EMPTY_REGISTRY), 3500);
+    const timeoutId = window.setTimeout(() => finish(EMPTY_REGISTRY), REGISTRY_FETCH_TIMEOUT_MS);
 
     ws.addEventListener('message', (event) => {
       let message: Record<string, unknown>;
@@ -188,6 +232,11 @@ async function fetchRegistrySnapshot(baseUrl: string, token: string): Promise<Re
       if (!settled) finish(EMPTY_REGISTRY);
     });
   });
+}
+
+function getRegistryCacheDuration(value: RegistryResults): number {
+  const hasRegistryData = value.areas.length > 0 || value.devices.length > 0 || value.entities.length > 0;
+  return hasRegistryData ? REGISTRY_CACHE_TTL_MS : EMPTY_REGISTRY_CACHE_TTL_MS;
 }
 
 function createWebSocketUrl(baseUrl: string): string {

--- a/src/components/widgets/homeAssistant/components.tsx
+++ b/src/components/widgets/homeAssistant/components.tsx
@@ -1,0 +1,188 @@
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronRight,
+  Home,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import type { HomeAssistantEntity } from './types';
+import { formatState, isEntityOn } from './utils';
+
+export function HomeSetupState({
+  readOnly,
+  onSettingsClick,
+}: {
+  readOnly: boolean;
+  onSettingsClick: () => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 p-4 text-center">
+      <Home className="size-8 text-muted-foreground" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">Connect Home Assistant</p>
+        <p className="text-xs text-muted-foreground">
+          Add your Home Assistant URL and a long-lived access token.
+        </p>
+      </div>
+      {!readOnly ? (
+        <Button type="button" size="sm" onClick={onSettingsClick}>
+          Configure
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export function HomeLoadingState({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className={cn('flex h-full flex-col gap-2 p-3', compact && 'p-2')}>
+      <Skeleton className="h-8 w-24" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-4/5" />
+    </div>
+  );
+}
+
+export function HomeErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 p-4 text-center">
+      <AlertTriangle className="size-7 text-destructive" aria-hidden="true" />
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">Home Assistant unavailable</p>
+        <p className="line-clamp-3 text-xs text-muted-foreground">{message}</p>
+      </div>
+      <Button type="button" size="sm" variant="outline" onClick={onRetry}>
+        <RefreshCw data-icon="inline-start" />
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+export function HomeMetricTile({
+  label,
+  value,
+  tone = 'neutral',
+  compact = false,
+}: {
+  label: string;
+  value: string | number;
+  tone?: 'neutral' | 'good' | 'warning' | 'danger';
+  compact?: boolean;
+}) {
+  return (
+    <div className={cn(
+      'min-w-0 rounded-md bg-muted/50 px-3 py-2',
+      tone === 'good' && 'bg-green-500/10 text-green-800 dark:text-green-200',
+      tone === 'warning' && 'bg-yellow-500/10 text-yellow-800 dark:text-yellow-200',
+      tone === 'danger' && 'bg-red-500/10 text-red-800 dark:text-red-200',
+      compact && 'px-2 py-1.5'
+    )}>
+      <div className={cn('truncate text-[11px] text-muted-foreground', tone !== 'neutral' && 'text-current/70')}>
+        {label}
+      </div>
+      <div className={cn('truncate font-semibold', compact ? 'text-sm' : 'text-lg')}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function HomeTinyStatus({
+  value,
+  label,
+  tone = 'neutral',
+}: {
+  value: string | number;
+  label: string;
+  tone?: 'neutral' | 'good' | 'warning' | 'danger';
+}) {
+  return (
+    <div className={cn(
+      'flex h-full flex-col items-center justify-center rounded-md p-1 text-center',
+      tone === 'good' && 'text-green-700 dark:text-green-300',
+      tone === 'warning' && 'text-yellow-700 dark:text-yellow-300',
+      tone === 'danger' && 'text-red-700 dark:text-red-300'
+    )}>
+      <div className="text-lg font-semibold leading-none">{value}</div>
+      <div className="mt-1 max-w-full truncate text-[10px] text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+export function HomeEntityRow({
+  entity,
+  action,
+  actionDisabled = false,
+  dense = false,
+}: {
+  entity: HomeAssistantEntity;
+  action?: () => void;
+  actionDisabled?: boolean;
+  dense?: boolean;
+}) {
+  const on = isEntityOn(entity);
+
+  return (
+    <div className={cn('flex min-w-0 items-center gap-2 rounded-md px-2 py-2 hover:bg-muted/60', dense && 'py-1.5')}>
+      <span className={cn(
+        'size-2 shrink-0 rounded-full bg-muted-foreground/40',
+        on && 'bg-green-500',
+        entity.state === 'unavailable' && 'bg-red-500'
+      )} />
+      <div className="min-w-0 flex-1">
+        <div className={cn('truncate font-medium text-foreground', dense ? 'text-xs' : 'text-sm')}>
+          {entity.name}
+        </div>
+        <div className="truncate text-[11px] text-muted-foreground">{formatState(entity)}</div>
+      </div>
+      {action ? (
+        <Button
+          type="button"
+          variant={on ? 'default' : 'outline'}
+          size="sm"
+          disabled={actionDisabled}
+          onClick={action}
+          className="h-7 shrink-0 px-2 text-xs"
+        >
+          {on ? 'On' : 'Off'}
+        </Button>
+      ) : (
+        <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+      )}
+    </div>
+  );
+}
+
+export function HomeEmptyState({ label = 'No matching devices' }: { label?: string }) {
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-2 p-4 text-center">
+      <CheckCircle2 className="size-7 text-muted-foreground" aria-hidden="true" />
+      <p className="text-sm font-medium text-foreground">{label}</p>
+      <p className="text-xs text-muted-foreground">Adjust the widget settings or add devices in Home Assistant.</p>
+    </div>
+  );
+}
+
+export function HomeRefreshingBadge({ refreshing }: { refreshing: boolean }) {
+  if (!refreshing) return null;
+
+  return (
+    <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+      <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+      Syncing
+    </span>
+  );
+}

--- a/src/components/widgets/homeAssistant/settings.tsx
+++ b/src/components/widgets/homeAssistant/settings.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  WidgetSettingsDialog,
+  WidgetSettingsDialogFooter,
+} from '../common/WidgetSettingsDialog';
+import type { HomeAssistantArea, HomeAssistantBaseConfig } from './types';
+import { formatEntityIds, parseEntityIds } from './utils';
+
+type HomeAssistantSettingsDialogProps<TConfig extends HomeAssistantBaseConfig> = {
+  open: boolean;
+  title: string;
+  config: TConfig;
+  areas?: HomeAssistantArea[];
+  showArea?: boolean;
+  showEntityIds?: boolean;
+  entityHelp?: string;
+  onConfigChange: (config: TConfig) => void;
+  onOpenChange: (open: boolean) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  onDelete?: () => void;
+  children?: React.ReactNode;
+};
+
+export function HomeAssistantSettingsDialog<TConfig extends HomeAssistantBaseConfig>({
+  open,
+  title,
+  config,
+  areas = [],
+  showArea = false,
+  showEntityIds = false,
+  entityHelp = 'Optional entity ids, one per line or comma separated.',
+  onConfigChange,
+  onOpenChange,
+  onCancel,
+  onSave,
+  onDelete,
+  children,
+}: HomeAssistantSettingsDialogProps<TConfig>) {
+  const updateConfig = (patch: Partial<TConfig>) => {
+    onConfigChange({ ...config, ...patch });
+  };
+
+  return (
+    <WidgetSettingsDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onCancel();
+          return;
+        }
+        onOpenChange(nextOpen);
+      }}
+      title={title}
+      description="Connect this widget to your Home Assistant HTTP API."
+      bodyClassName="flex flex-col gap-4 px-1"
+      footer={(
+        <WidgetSettingsDialogFooter
+          onDelete={onDelete}
+          onCancel={onCancel}
+          onSave={onSave}
+        />
+      )}
+    >
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="ha-title">Widget Title</Label>
+        <Input
+          id="ha-title"
+          value={config.title || ''}
+          onChange={(event) => updateConfig({ title: event.target.value } as Partial<TConfig>)}
+          placeholder={title.replace(' Settings', '')}
+        />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="ha-url">Home Assistant URL</Label>
+          <Input
+            id="ha-url"
+            value={config.baseUrl || ''}
+            onChange={(event) => updateConfig({ baseUrl: event.target.value } as Partial<TConfig>)}
+            placeholder="http://homeassistant.local:8123"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="ha-refresh">Refresh Seconds</Label>
+          <Input
+            id="ha-refresh"
+            type="number"
+            min={10}
+            value={String(config.refreshInterval || 30)}
+            onChange={(event) => updateConfig({ refreshInterval: Number(event.target.value) || 30 } as Partial<TConfig>)}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="ha-token">Long-Lived Access Token</Label>
+        <Input
+          id="ha-token"
+          type="password"
+          value={config.apiToken || ''}
+          onChange={(event) => updateConfig({ apiToken: event.target.value } as Partial<TConfig>)}
+          placeholder="Paste a Home Assistant token"
+        />
+        <p className="text-xs text-muted-foreground">
+          Create this in Home Assistant profile settings. Your browser may need HA CORS configured.
+        </p>
+      </div>
+
+      {showArea ? (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="ha-area">Room / Area</Label>
+          {areas.length ? (
+            <Select
+              value={config.areaId || 'all'}
+              onValueChange={(value) => updateConfig({ areaId: value === 'all' ? '' : value } as Partial<TConfig>)}
+            >
+              <SelectTrigger id="ha-area" className="w-full">
+                <SelectValue placeholder="All rooms" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All rooms</SelectItem>
+                {areas.map((area) => (
+                  <SelectItem key={area.area_id} value={area.area_id}>{area.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : (
+            <Input
+              id="ha-area"
+              value={config.areaId || ''}
+              onChange={(event) => updateConfig({ areaId: event.target.value } as Partial<TConfig>)}
+              placeholder="Optional area id"
+            />
+          )}
+        </div>
+      ) : null}
+
+      {showEntityIds ? (
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="ha-entities">Entity IDs</Label>
+          <textarea
+            id="ha-entities"
+            value={formatEntityIds(config.entityIds)}
+            onChange={(event) => updateConfig({ entityIds: parseEntityIds(event.target.value) } as Partial<TConfig>)}
+            placeholder="light.kitchen&#10;climate.living_room"
+            className="min-h-24 w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          />
+          <p className="text-xs text-muted-foreground">{entityHelp}</p>
+        </div>
+      ) : null}
+
+      {children}
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => updateConfig({
+          baseUrl: config.baseUrl || 'http://homeassistant.local:8123',
+          refreshInterval: config.refreshInterval || 30,
+        } as Partial<TConfig>)}
+      >
+        Use Local Defaults
+      </Button>
+    </WidgetSettingsDialog>
+  );
+}

--- a/src/components/widgets/homeAssistant/types.ts
+++ b/src/components/widgets/homeAssistant/types.ts
@@ -1,0 +1,112 @@
+export type HomeAssistantDomain =
+  | 'alarm_control_panel'
+  | 'binary_sensor'
+  | 'button'
+  | 'climate'
+  | 'cover'
+  | 'fan'
+  | 'humidifier'
+  | 'light'
+  | 'lock'
+  | 'media_player'
+  | 'person'
+  | 'scene'
+  | 'script'
+  | 'sensor'
+  | 'switch'
+  | 'update'
+  | 'vacuum'
+  | 'weather'
+  | string;
+
+export type HomeAssistantAttributes = Record<string, unknown> & {
+  friendly_name?: string;
+  device_class?: string;
+  unit_of_measurement?: string;
+  current_temperature?: number;
+  temperature?: number;
+  icon?: string;
+};
+
+export interface HomeAssistantState {
+  entity_id: string;
+  state: string;
+  attributes: HomeAssistantAttributes;
+  last_changed?: string;
+  last_updated?: string;
+}
+
+export interface HomeAssistantArea {
+  area_id: string;
+  name: string;
+  icon?: string | null;
+}
+
+export interface HomeAssistantDevice {
+  id: string;
+  area_id?: string | null;
+  name?: string | null;
+  name_by_user?: string | null;
+  hidden_by?: string | null;
+  disabled_by?: string | null;
+}
+
+export interface HomeAssistantEntityRegistryEntry {
+  entity_id: string;
+  area_id?: string | null;
+  device_id?: string | null;
+  entity_category?: string | null;
+  hidden_by?: string | null;
+  disabled_by?: string | null;
+  name?: string | null;
+  original_name?: string | null;
+}
+
+export interface HomeAssistantEntity {
+  entityId: string;
+  domain: HomeAssistantDomain;
+  name: string;
+  state: string;
+  attributes: HomeAssistantAttributes;
+  areaId?: string;
+  areaName?: string;
+  deviceId?: string;
+  deviceClass?: string;
+  entityCategory?: string;
+  unit?: string;
+  lastChanged?: string;
+  lastUpdated?: string;
+  hidden: boolean;
+  disabled: boolean;
+}
+
+export interface HomeAssistantSnapshot {
+  states: HomeAssistantState[];
+  areas: HomeAssistantArea[];
+  devices: HomeAssistantDevice[];
+  registryEntities: HomeAssistantEntityRegistryEntry[];
+  entities: HomeAssistantEntity[];
+  loadedAt: string;
+}
+
+export interface HomeAssistantBaseConfig extends Record<string, unknown> {
+  id?: string;
+  title?: string;
+  baseUrl?: string;
+  apiToken?: string;
+  refreshInterval?: number;
+  areaId?: string;
+  entityIds?: string[];
+  readOnly?: boolean;
+}
+
+export type HomeAssistantConnectionConfig = Pick<HomeAssistantBaseConfig, 'baseUrl' | 'apiToken'>;
+
+export type HomeAssistantIssueKind = 'unavailable' | 'battery' | 'update';
+
+export interface HomeAssistantHealthIssue {
+  kind: HomeAssistantIssueKind;
+  entity: HomeAssistantEntity;
+  label: string;
+  severity: 'info' | 'warning' | 'critical';
+}

--- a/src/components/widgets/homeAssistant/types.ts
+++ b/src/components/widgets/homeAssistant/types.ts
@@ -25,6 +25,7 @@ export type HomeAssistantAttributes = Record<string, unknown> & {
   unit_of_measurement?: string;
   current_temperature?: number;
   temperature?: number;
+  temperature_unit?: string;
   icon?: string;
 };
 

--- a/src/components/widgets/homeAssistant/useHomeAssistantData.ts
+++ b/src/components/widgets/homeAssistant/useHomeAssistantData.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { fetchHomeAssistantSnapshot } from './client';
+import type { HomeAssistantBaseConfig, HomeAssistantSnapshot } from './types';
+
+const DEFAULT_REFRESH_INTERVAL = 30;
+
+export function useHomeAssistantData(config: HomeAssistantBaseConfig) {
+  const [snapshot, setSnapshot] = useState<HomeAssistantSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canFetch = Boolean(config.baseUrl?.trim() && config.apiToken?.trim());
+  const refreshInterval = Math.max(10, Number(config.refreshInterval || DEFAULT_REFRESH_INTERVAL));
+
+  const fetchData = useCallback(async (mode: 'initial' | 'refresh' = 'refresh') => {
+    if (!canFetch) {
+      setSnapshot(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 12000);
+
+    try {
+      if (mode === 'initial') {
+        setLoading(true);
+      } else {
+        setRefreshing(true);
+      }
+      setError(null);
+      const nextSnapshot = await fetchHomeAssistantSnapshot(config, controller.signal);
+      setSnapshot(nextSnapshot);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load Home Assistant');
+    } finally {
+      window.clearTimeout(timeout);
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [canFetch, config]);
+
+  useEffect(() => {
+    fetchData('initial');
+    if (!canFetch) return undefined;
+
+    const interval = window.setInterval(() => {
+      fetchData('refresh');
+    }, refreshInterval * 1000);
+
+    return () => window.clearInterval(interval);
+  }, [canFetch, fetchData, refreshInterval]);
+
+  return useMemo(() => ({
+    snapshot,
+    loading,
+    refreshing,
+    error,
+    canFetch,
+    refresh: () => fetchData('refresh'),
+  }), [canFetch, error, fetchData, loading, refreshing, snapshot]);
+}

--- a/src/components/widgets/homeAssistant/utils.ts
+++ b/src/components/widgets/homeAssistant/utils.ts
@@ -11,6 +11,7 @@ import type {
 const UNAVAILABLE_STATES = new Set(['unavailable', 'unknown']);
 const ON_STATES = new Set(['on', 'open', 'opening', 'unlocked', 'home', 'heat', 'cool', 'heat_cool', 'playing']);
 const LOW_BATTERY_CLASSES = new Set(['battery']);
+const OPEN_SECURITY_STATES = new Set(['open', 'unlocked', 'triggered']);
 
 export const LIGHT_DOMAINS = ['light'];
 export const CLIMATE_DOMAINS = ['climate', 'fan', 'humidifier'];
@@ -117,6 +118,10 @@ export function isEntityOn(entity: HomeAssistantEntity): boolean {
   return ON_STATES.has(entity.state);
 }
 
+export function isActiveSecurityEntity(entity: HomeAssistantEntity): boolean {
+  return OPEN_SECURITY_STATES.has(entity.state) || (entity.domain === 'binary_sensor' && isEntityOn(entity));
+}
+
 export function canToggleEntity(entity: HomeAssistantEntity): boolean {
   return ['light', 'switch', 'fan', 'cover', 'lock', 'input_boolean'].includes(entity.domain);
 }
@@ -146,6 +151,19 @@ export function getClimateTemperature(entity: HomeAssistantEntity): number | nul
   if (typeof direct === 'number') return direct;
   if (Number.isFinite(stateNumber)) return stateNumber;
   return null;
+}
+
+export function isTemperatureEntity(entity: HomeAssistantEntity): boolean {
+  return entity.domain !== 'sensor' || entity.deviceClass === 'temperature';
+}
+
+export function getTemperatureUnit(entity: HomeAssistantEntity): string | undefined {
+  const unit = entity.unit || entity.attributes.temperature_unit || entity.attributes.unit_of_measurement;
+  return typeof unit === 'string' ? unit : undefined;
+}
+
+export function formatTemperatureValue(value: number, unit?: string): string {
+  return `${value}${unit || ''}`;
 }
 
 export function getHealthIssues(snapshot: HomeAssistantSnapshot | null, batteryThreshold = 20): HomeAssistantHealthIssue[] {
@@ -235,9 +253,9 @@ function isDiagnosticEntity(entity: HomeAssistantEntity): boolean {
 }
 
 function getEntitySortRank(entity: HomeAssistantEntity): number {
-  if (isUnavailable(entity)) return 0;
-  if (isEntityOn(entity)) return 1;
-  return 2;
+  if (isEntityOn(entity)) return 0;
+  if (isUnavailable(entity)) return 2;
+  return 1;
 }
 
 function severityRank(severity: HomeAssistantHealthIssue['severity']): number {

--- a/src/components/widgets/homeAssistant/utils.ts
+++ b/src/components/widgets/homeAssistant/utils.ts
@@ -1,0 +1,247 @@
+import type {
+  HomeAssistantArea,
+  HomeAssistantDevice,
+  HomeAssistantEntity,
+  HomeAssistantEntityRegistryEntry,
+  HomeAssistantHealthIssue,
+  HomeAssistantSnapshot,
+  HomeAssistantState,
+} from './types';
+
+const UNAVAILABLE_STATES = new Set(['unavailable', 'unknown']);
+const ON_STATES = new Set(['on', 'open', 'opening', 'unlocked', 'home', 'heat', 'cool', 'heat_cool', 'playing']);
+const LOW_BATTERY_CLASSES = new Set(['battery']);
+
+export const LIGHT_DOMAINS = ['light'];
+export const CLIMATE_DOMAINS = ['climate', 'fan', 'humidifier'];
+export const ROOM_DOMAINS = ['light', 'switch', 'climate', 'fan', 'cover', 'lock', 'sensor', 'binary_sensor', 'media_player'];
+
+export function buildHomeAssistantEntities(
+  states: HomeAssistantState[],
+  registry: {
+    areas: HomeAssistantArea[];
+    devices: HomeAssistantDevice[];
+    entities: HomeAssistantEntityRegistryEntry[];
+  }
+): HomeAssistantEntity[] {
+  const areaById = new Map(registry.areas.map((area) => [area.area_id, area]));
+  const deviceById = new Map(registry.devices.map((device) => [device.id, device]));
+  const registryByEntityId = new Map(registry.entities.map((entity) => [entity.entity_id, entity]));
+
+  return states.map((state) => {
+    const registryEntry = registryByEntityId.get(state.entity_id);
+    const device = registryEntry?.device_id ? deviceById.get(registryEntry.device_id) : undefined;
+    const areaId = registryEntry?.area_id || device?.area_id || undefined;
+    const area = areaId ? areaById.get(areaId) : undefined;
+    const domain = getDomain(state.entity_id);
+
+    return {
+      entityId: state.entity_id,
+      domain,
+      name: getEntityName(state, registryEntry),
+      state: state.state,
+      attributes: state.attributes,
+      areaId,
+      areaName: area?.name,
+      deviceId: registryEntry?.device_id || undefined,
+      deviceClass: getStringAttribute(state, 'device_class'),
+      entityCategory: registryEntry?.entity_category || undefined,
+      unit: getStringAttribute(state, 'unit_of_measurement'),
+      lastChanged: state.last_changed,
+      lastUpdated: state.last_updated,
+      hidden: Boolean(registryEntry?.hidden_by || device?.hidden_by),
+      disabled: Boolean(registryEntry?.disabled_by || device?.disabled_by),
+    };
+  });
+}
+
+export function getDomain(entityId: string): string {
+  return entityId.split('.')[0] || '';
+}
+
+export function getEntityName(
+  state: HomeAssistantState,
+  registryEntry?: HomeAssistantEntityRegistryEntry
+): string {
+  return registryEntry?.name || state.attributes.friendly_name || registryEntry?.original_name || state.entity_id;
+}
+
+export function parseEntityIds(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => item.trim()).filter(Boolean);
+  }
+
+  return (value || '')
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function formatEntityIds(entityIds?: string[]): string {
+  return (entityIds || []).join('\n');
+}
+
+export function selectEntities(
+  snapshot: HomeAssistantSnapshot | null,
+  options: {
+    domains?: string[];
+    areaId?: string;
+    entityIds?: string[];
+    includeDiagnostic?: boolean;
+  } = {}
+): HomeAssistantEntity[] {
+  if (!snapshot) return [];
+
+  const selectedIds = new Set(options.entityIds || []);
+  const domains = new Set(options.domains || []);
+
+  return snapshot.entities
+    .filter((entity) => !entity.hidden && !entity.disabled)
+    .filter((entity) => options.includeDiagnostic || !isDiagnosticEntity(entity))
+    .filter((entity) => domains.size === 0 || domains.has(entity.domain))
+    .filter((entity) => !options.areaId || entity.areaId === options.areaId)
+    .filter((entity) => selectedIds.size === 0 || selectedIds.has(entity.entityId))
+    .sort((a, b) => getEntitySortRank(a) - getEntitySortRank(b) || a.name.localeCompare(b.name));
+}
+
+export function getAreaName(snapshot: HomeAssistantSnapshot | null, areaId?: string): string {
+  if (!areaId) return 'All rooms';
+  return snapshot?.areas.find((area) => area.area_id === areaId)?.name || toTitle(areaId);
+}
+
+export function isUnavailable(entity: HomeAssistantEntity): boolean {
+  return UNAVAILABLE_STATES.has(entity.state);
+}
+
+export function isEntityOn(entity: HomeAssistantEntity): boolean {
+  return ON_STATES.has(entity.state);
+}
+
+export function canToggleEntity(entity: HomeAssistantEntity): boolean {
+  return ['light', 'switch', 'fan', 'cover', 'lock', 'input_boolean'].includes(entity.domain);
+}
+
+export function getToggleService(entity: HomeAssistantEntity): { domain: string; service: string } | null {
+  if (entity.domain === 'cover') {
+    return { domain: 'cover', service: entity.state === 'open' ? 'close_cover' : 'open_cover' };
+  }
+
+  if (entity.domain === 'lock') {
+    return { domain: 'lock', service: entity.state === 'unlocked' ? 'lock' : 'unlock' };
+  }
+
+  if (['light', 'switch', 'fan', 'input_boolean'].includes(entity.domain)) {
+    return { domain: entity.domain, service: 'toggle' };
+  }
+
+  return null;
+}
+
+export function getClimateTemperature(entity: HomeAssistantEntity): number | null {
+  const current = entity.attributes.current_temperature;
+  const direct = entity.attributes.temperature;
+  const stateNumber = Number(entity.state);
+
+  if (typeof current === 'number') return current;
+  if (typeof direct === 'number') return direct;
+  if (Number.isFinite(stateNumber)) return stateNumber;
+  return null;
+}
+
+export function getHealthIssues(snapshot: HomeAssistantSnapshot | null, batteryThreshold = 20): HomeAssistantHealthIssue[] {
+  if (!snapshot) return [];
+
+  const issues: HomeAssistantHealthIssue[] = [];
+
+  for (const entity of snapshot.entities) {
+    if (entity.hidden || entity.disabled) continue;
+
+    if (isUnavailable(entity)) {
+      issues.push({
+        kind: 'unavailable',
+        entity,
+        label: 'Unavailable',
+        severity: 'critical',
+      });
+      continue;
+    }
+
+    if (entity.domain === 'update' && entity.state === 'on') {
+      issues.push({
+        kind: 'update',
+        entity,
+        label: 'Update available',
+        severity: 'info',
+      });
+      continue;
+    }
+
+    if (entity.domain === 'sensor' && entity.deviceClass && LOW_BATTERY_CLASSES.has(entity.deviceClass)) {
+      const battery = Number(entity.state);
+      if (Number.isFinite(battery) && battery <= batteryThreshold) {
+        issues.push({
+          kind: 'battery',
+          entity,
+          label: `${battery}% battery`,
+          severity: battery <= 10 ? 'critical' : 'warning',
+        });
+      }
+    }
+  }
+
+  return issues.sort((a, b) => severityRank(a.severity) - severityRank(b.severity) || a.entity.name.localeCompare(b.entity.name));
+}
+
+export function formatState(entity: HomeAssistantEntity): string {
+  if (entity.unit) return `${entity.state} ${entity.unit}`;
+  return toTitle(entity.state);
+}
+
+export function formatRelativeTime(value?: string): string {
+  if (!value) return 'Never';
+  const date = new Date(value);
+  const diffMs = Date.now() - date.getTime();
+  const diffMinutes = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffDays > 0) return `${diffDays}d ago`;
+  if (diffHours > 0) return `${diffHours}h ago`;
+  if (diffMinutes > 0) return `${diffMinutes}m ago`;
+  return 'Just now';
+}
+
+export function toTitle(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+export function toPersistedHomeAssistantConfig<T extends Record<string, unknown>>(config: T): T {
+  const { onDelete, onUpdate, readOnly, ...persisted } = config;
+  void onDelete;
+  void onUpdate;
+  void readOnly;
+  return persisted as T;
+}
+
+function getStringAttribute(state: HomeAssistantState, key: keyof HomeAssistantState['attributes']): string | undefined {
+  const value = state.attributes[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isDiagnosticEntity(entity: HomeAssistantEntity): boolean {
+  return entity.entityCategory === 'diagnostic' || entity.entityCategory === 'config';
+}
+
+function getEntitySortRank(entity: HomeAssistantEntity): number {
+  if (isUnavailable(entity)) return 0;
+  if (isEntityOn(entity)) return 1;
+  return 2;
+}
+
+function severityRank(severity: HomeAssistantHealthIssue['severity']): number {
+  if (severity === 'critical') return 0;
+  if (severity === 'warning') return 1;
+  return 2;
+}

--- a/src/components/widgets/index.ts
+++ b/src/components/widgets/index.ts
@@ -33,6 +33,11 @@ const RivenWidget = React.lazy(() => import('./RivenWidget/index'));
 const CronHealthWidget = React.lazy(() => import('./CronHealthWidget/index'));
 const KumaWidget = React.lazy(() => import('./KumaWidget/index'));
 const HealthchecksWidget = React.lazy(() => import('./HealthchecksWidget/index'));
+const HomeOverviewWidget = React.lazy(() => import('./HomeOverviewWidget/index'));
+const HomeRoomWidget = React.lazy(() => import('./HomeRoomWidget/index'));
+const HomeLightsWidget = React.lazy(() => import('./HomeLightsWidget/index'));
+const HomeClimateWidget = React.lazy(() => import('./HomeClimateWidget/index'));
+const HomeDeviceHealthWidget = React.lazy(() => import('./HomeDeviceHealthWidget/index'));
 
 // Export widget types
 export * from './CalendarWidget/types';
@@ -66,6 +71,11 @@ export * from './RivenWidget/types';
 export * from './CronHealthWidget/types';
 export * from './KumaWidget/types';
 export * from './HealthchecksWidget/types';
+export * from './HomeOverviewWidget/types';
+export * from './HomeRoomWidget/types';
+export * from './HomeLightsWidget/types';
+export * from './HomeClimateWidget/types';
+export * from './HomeDeviceHealthWidget/types';
 
 // Enhanced Widget Config
 export interface EnhancedWidgetConfig extends WidgetConfig {
@@ -106,6 +116,11 @@ const TINY_READY_WIDGET_TYPES = new Set([
   'riven',
   'kuma',
   'healthchecks',
+  'home-overview',
+  'home-room',
+  'home-lights',
+  'home-climate',
+  'home-device-health',
 ]);
 
 // Widget registry with enhanced metadata
@@ -441,6 +456,61 @@ const BASE_WIDGET_REGISTRY: EnhancedWidgetConfig[] = [
     description: 'Display cron and dead-man-switch checks from Healthchecks'
   },
   {
+    type: 'home-overview',
+    name: 'Home Overview',
+    icon: 'Home',
+    minWidth: 2,
+    minHeight: 2,
+    defaultWidth: 3,
+    defaultHeight: 3,
+    category: 'Home',
+    description: 'See lights, climate, security, and health at a glance'
+  },
+  {
+    type: 'home-room',
+    name: 'Room Control',
+    icon: 'DoorOpen',
+    minWidth: 2,
+    minHeight: 2,
+    defaultWidth: 3,
+    defaultHeight: 3,
+    category: 'Home',
+    description: 'Control devices for one Home Assistant room or area'
+  },
+  {
+    type: 'home-lights',
+    name: 'Lights',
+    icon: 'Lightbulb',
+    minWidth: 2,
+    minHeight: 2,
+    defaultWidth: 2,
+    defaultHeight: 3,
+    category: 'Home',
+    description: 'Toggle and review Home Assistant lights'
+  },
+  {
+    type: 'home-climate',
+    name: 'Climate',
+    icon: 'Thermometer',
+    minWidth: 2,
+    minHeight: 2,
+    defaultWidth: 2,
+    defaultHeight: 3,
+    category: 'Home',
+    description: 'Monitor thermostats, fans, humidity, and temperature sensors'
+  },
+  {
+    type: 'home-device-health',
+    name: 'Device Health',
+    icon: 'Activity',
+    minWidth: 2,
+    minHeight: 2,
+    defaultWidth: 3,
+    defaultHeight: 3,
+    category: 'Home',
+    description: 'Track unavailable devices, low batteries, and updates'
+  },
+  {
     type: 'cron-health',
     name: 'System Health',
     icon: 'Activity',
@@ -468,6 +538,7 @@ export const WIDGET_CATEGORIES = [
   { id: 'social', name: 'Social' },
   { id: 'utilities', name: 'Utilities' },
   { id: 'finance', name: 'Finance' },
+  { id: 'home', name: 'Home' },
   { id: 'entertainment', name: 'Entertainment' },
   { id: 'local-services', name: 'Local Services' }
 ];
@@ -511,6 +582,11 @@ const WIDGET_COMPONENTS: Record<string, LazyWidgetComponent> = {
   'riven': RivenWidget as unknown as LazyWidgetComponent,
   'kuma': KumaWidget as unknown as LazyWidgetComponent,
   'healthchecks': HealthchecksWidget as unknown as LazyWidgetComponent,
+  'home-overview': HomeOverviewWidget as unknown as LazyWidgetComponent,
+  'home-room': HomeRoomWidget as unknown as LazyWidgetComponent,
+  'home-lights': HomeLightsWidget as unknown as LazyWidgetComponent,
+  'home-climate': HomeClimateWidget as unknown as LazyWidgetComponent,
+  'home-device-health': HomeDeviceHealthWidget as unknown as LazyWidgetComponent,
   'cron-health': CronHealthWidget as unknown as LazyWidgetComponent,
 };
 

--- a/tests/unit/homeAssistantUtils.test.ts
+++ b/tests/unit/homeAssistantUtils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import type { HomeAssistantState } from '@/components/widgets/homeAssistant/types';
+import {
+  buildHomeAssistantEntities,
+  getHealthIssues,
+  parseEntityIds,
+  selectEntities,
+} from '@/components/widgets/homeAssistant/utils';
+
+const states: HomeAssistantState[] = [
+  {
+    entity_id: 'light.kitchen',
+    state: 'on',
+    attributes: { friendly_name: 'Kitchen Light' },
+  },
+  {
+    entity_id: 'sensor.remote_battery',
+    state: '12',
+    attributes: {
+      friendly_name: 'Remote Battery',
+      device_class: 'battery',
+      unit_of_measurement: '%',
+    },
+  },
+  {
+    entity_id: 'switch.router',
+    state: 'unavailable',
+    attributes: { friendly_name: 'Router' },
+  },
+  {
+    entity_id: 'sensor.router_signal',
+    state: '80',
+    attributes: { friendly_name: 'Router Signal' },
+  },
+];
+
+describe('Home Assistant widget utilities', () => {
+  it('parses entity id input from commas and new lines', () => {
+    expect(parseEntityIds('light.kitchen, climate.living\nsensor.temp')).toEqual([
+      'light.kitchen',
+      'climate.living',
+      'sensor.temp',
+    ]);
+  });
+
+  it('enriches states with room and registry metadata', () => {
+    const entities = buildHomeAssistantEntities(states, {
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      devices: [],
+      entities: [
+        { entity_id: 'light.kitchen', area_id: 'kitchen' },
+        { entity_id: 'sensor.remote_battery', area_id: 'kitchen' },
+      ],
+    });
+
+    expect(entities.find((entity) => entity.entityId === 'light.kitchen')).toMatchObject({
+      domain: 'light',
+      areaId: 'kitchen',
+      areaName: 'Kitchen',
+      name: 'Kitchen Light',
+    });
+  });
+
+  it('selects by domain and area', () => {
+    const snapshot = {
+      loadedAt: new Date().toISOString(),
+      states,
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      devices: [],
+      registryEntities: [],
+      entities: buildHomeAssistantEntities(states, {
+        areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+        devices: [],
+        entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+      }),
+    };
+
+    expect(selectEntities(snapshot, { domains: ['light'], areaId: 'kitchen' }).map((entity) => entity.entityId)).toEqual([
+      'light.kitchen',
+    ]);
+  });
+
+  it('detects unavailable and low battery health issues', () => {
+    const snapshot = {
+      loadedAt: new Date().toISOString(),
+      states,
+      areas: [],
+      devices: [],
+      registryEntities: [],
+      entities: buildHomeAssistantEntities(states, {
+        areas: [],
+        devices: [],
+        entities: [],
+      }),
+    };
+
+    expect(getHealthIssues(snapshot, 20).map((issue) => issue.kind)).toEqual([
+      'unavailable',
+      'battery',
+    ]);
+  });
+});

--- a/tests/unit/homeAssistantUtils.test.ts
+++ b/tests/unit/homeAssistantUtils.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import type { HomeAssistantState } from '@/components/widgets/homeAssistant/types';
 import {
   buildHomeAssistantEntities,
+  formatTemperatureValue,
   getHealthIssues,
+  getTemperatureUnit,
+  isActiveSecurityEntity,
   parseEntityIds,
   selectEntities,
 } from '@/components/widgets/homeAssistant/utils';
@@ -32,6 +35,25 @@ const states: HomeAssistantState[] = [
     entity_id: 'sensor.router_signal',
     state: '80',
     attributes: { friendly_name: 'Router Signal' },
+  },
+  {
+    entity_id: 'light.living_room',
+    state: 'off',
+    attributes: { friendly_name: 'Living Room Light' },
+  },
+  {
+    entity_id: 'binary_sensor.front_door',
+    state: 'on',
+    attributes: { friendly_name: 'Front Door', device_class: 'door' },
+  },
+  {
+    entity_id: 'climate.living_room',
+    state: 'heat',
+    attributes: {
+      friendly_name: 'Living Room Thermostat',
+      current_temperature: 72,
+      temperature_unit: '°F',
+    },
   },
 ];
 
@@ -79,6 +101,49 @@ describe('Home Assistant widget utilities', () => {
     expect(selectEntities(snapshot, { domains: ['light'], areaId: 'kitchen' }).map((entity) => entity.entityId)).toEqual([
       'light.kitchen',
     ]);
+  });
+
+  it('sorts active entities before idle and unavailable entities', () => {
+    const snapshot = {
+      loadedAt: new Date().toISOString(),
+      states,
+      areas: [],
+      devices: [],
+      registryEntities: [],
+      entities: buildHomeAssistantEntities(states, {
+        areas: [],
+        devices: [],
+        entities: [],
+      }),
+    };
+
+    expect(selectEntities(snapshot, { domains: ['light', 'switch'] }).map((entity) => entity.entityId)).toEqual([
+      'light.kitchen',
+      'light.living_room',
+      'switch.router',
+    ]);
+  });
+
+  it('counts active binary sensors as security activity', () => {
+    const entity = buildHomeAssistantEntities(states, {
+      areas: [],
+      devices: [],
+      entities: [],
+    }).find((item) => item.entityId === 'binary_sensor.front_door');
+
+    expect(entity).toBeDefined();
+    expect(isActiveSecurityEntity(entity!)).toBe(true);
+  });
+
+  it('formats climate temperatures with Home Assistant units', () => {
+    const entity = buildHomeAssistantEntities(states, {
+      areas: [],
+      devices: [],
+      entities: [],
+    }).find((item) => item.entityId === 'climate.living_room');
+
+    expect(entity).toBeDefined();
+    expect(formatTemperatureValue(72, getTemperatureUnit(entity!))).toBe('72°F');
   });
 
   it('detects unavailable and low battery health issues', () => {


### PR DESCRIPTION
## Summary
- Adds a new Home widget category with Home Overview, Room Control, Lights, Climate, and Device Health widgets.
- Adds shared Home Assistant client/settings/state primitives for REST/WebSocket state loading, registry enrichment, service calls, and setup/error/empty/read-only UI.
- Adds unit coverage for Home Assistant entity parsing, enrichment, filtering, and health issue detection.

## Product / PM-ready acceptance criteria
- Tiny states show one glanceable signal for each Home widget without standard header chrome.
- Compact and standard states preserve the primary widget job: overview metrics, room controls, light toggles, climate status, and health issues.
- Wide/app-like states expand into richer lists without moving core workflows into settings.
- Settings use the standard widget settings dialog and preserve delete through the shared footer path.
- Loading, empty, error, configured, and read-only states are handled through shared Home widget primitives.

## Validation
- bun run build:types
- bun run test
- bun run lint (passes with existing warnings)
- bun run test:e2e
- bun run build

## Release note
The release workflow only runs from a vMAJOR.MINOR.PATCH tag pointing at current origin/main. Merge this PR first, then tag main to publish the Docker/GitHub release.