### PR TITLE
Polish Home Assistant widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,36 +177,74 @@ VITE_ALLOWED_HOSTS=your-domain.com,another-domain.com docker compose up -d
 
 ### Widget Gallery
 
-Boxento comes with a diverse collection of widgets organized by category:
+Boxento comes with a diverse collection of widgets organized by the same
+categories you see in **Add Widget**:
 
 #### Productivity
-- **Todo Widget**: Track tasks and stay organized
-- **Todoist Widget**: Sync with your Todoist tasks
-- **Calendar Widget**: Display upcoming events
-- **Notes Widget**: Capture thoughts and ideas
-- **Pomodoro Timer**: Boost productivity with time management
-- **Habit Tracker**: Build daily habits with streak tracking
+
+- **Calendar**: Display upcoming events and appointments
+- **Quick Links**: Save and quickly access favorite links
+- **Notes**: Take and save quick notes
+- **Todo List**: Manage tasks and to-dos
+- **Pomodoro Timer**: Time management with the Pomodoro Technique
+- **GitHub Streak**: Track GitHub contribution streaks and activity
+- **Todoist Tasks**: View and manage Todoist tasks
+- **Habit Tracker**: Track daily habits and build streaks
 - **Countdown**: Count down to important events and dates
-- **GitHub Streak Tracker**: Monitor your GitHub activity
 
 #### Information
-- **Weather Widget**: Check current conditions and forecasts
-- **World Clocks Widget**: Bauhaus-inspired clocks across time zones
-- **RSS Feed Widget**: Stay updated with favorite content
-- **Readwise Widget**: Access your reading highlights
-- **Year Progress**: Visualize progress through the year
 
-#### Finance & Travel
-- **Currency Converter**: Live exchange rates
-- **UF (Chile) Widget**: Display UF value in CLP
+- **Weather**: Display current weather and forecast
+- **World Clocks**: Display time across different time zones
+- **Readwise Highlights**: Display highlights from Readwise
+- **RSS Feed**: Display feeds from favorite websites
+- **Year Progress**: Visualize progress through the year
+- **Reader**: Surface articles from Readwise Reader
+
+#### Finance
+
+- **Currency Converter**: Convert currencies using live exchange rates
+- **UF (Chile)**: Display UF value in CLP
+
+#### Travel
+
 - **Flight Tracker**: Monitor real-time flight status
 
-#### Entertainment & Utilities
-- **YouTube Widget**: Watch videos directly
+#### Education
+
 - **Geography Quiz**: Test your knowledge
-- **Quick Links**: Organize favorite websites
-- **QR Code Generator**: Generate QR codes from text or URLs
-- **Embed Widget**: Embed external content via iframe or images
+
+#### Entertainment
+
+- **YouTube Video**: Watch YouTube videos directly on your dashboard
+
+#### Utilities
+
+- **Embed**: Embed external content via iframe URL
+- **QR Code**: Generate QR codes from text or URLs
+
+#### Local Services
+
+- **Services**: Monitor and access self-hosted services
+- **Ollama Chat**: Chat with local Ollama AI models
+- **Paisa Finance**: View net worth and asset breakdown from Paisa
+- **Jellyfin**: View now playing and recently added media from Jellyfin
+- **Fava**: View Beancount balance sheet and income statement
+- **Riven**: Quick access to Riven media automation
+- **System Health**: Monitor cron jobs and launchd services
+
+#### Self-hosted
+
+- **Uptime Kuma**: Display service monitors from an Uptime Kuma status feed
+- **Healthchecks**: Display cron and dead-man-switch checks from Healthchecks
+
+#### Home
+
+- **Home Overview**: See lights, climate, security, and device health at a glance
+- **Room Control**: Control devices for one Home Assistant room or area
+- **Lights**: Toggle and review Home Assistant lights with realtime status
+- **Climate**: Monitor thermostats, fans, humidity, and temperature sensors
+- **Device Health**: Track unavailable devices, low batteries, and updates
 
 ### Customization
 

--- a/src/components/widgets/HomeLightsWidget/index.tsx
+++ b/src/components/widgets/HomeLightsWidget/index.tsx
@@ -17,10 +17,14 @@ import {
   HomeTinyStatus,
 } from '../homeAssistant/components';
 import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantOptimisticStates } from '../homeAssistant/optimisticEntityStates';
 import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
 import {
   LIGHT_DOMAINS,
+  applyEntityStateOverrides,
+  getToggleAction,
   isEntityOn,
+  removeRedundantAggregateEntities,
   selectEntities,
   toPersistedHomeAssistantConfig,
 } from '../homeAssistant/utils';
@@ -48,8 +52,14 @@ const HomeLightsWidget: React.FC<HomeLightsWidgetProps> = ({ width, height, conf
   const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
   const [draftConfig, setDraftConfig] = useState<HomeLightsWidgetConfig>(appliedConfig);
   const [showSettings, setShowSettings] = useState(false);
-  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
   const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+  const {
+    optimisticStateValues,
+    pendingEntityIds,
+    setOptimisticState,
+    clearOptimisticState,
+    setPendingEntity,
+  } = useHomeAssistantOptimisticStates(appliedConfig, snapshot);
 
   useEffect(() => {
     setDraftConfig(appliedConfig);
@@ -61,24 +71,32 @@ const HomeLightsWidget: React.FC<HomeLightsWidgetProps> = ({ width, height, conf
       areaId: appliedConfig.areaId,
       entityIds: appliedConfig.entityIds,
     });
+    const withOptimisticState = applyEntityStateOverrides(selected, optimisticStateValues);
+    const withoutAggregateDuplicates = removeRedundantAggregateEntities(withOptimisticState);
 
-    return appliedConfig.showOnlyOn ? selected.filter(isEntityOn) : selected;
-  }, [appliedConfig.areaId, appliedConfig.entityIds, appliedConfig.showOnlyOn, snapshot]);
+    return appliedConfig.showOnlyOn ? withoutAggregateDuplicates.filter(isEntityOn) : withoutAggregateDuplicates;
+  }, [appliedConfig.areaId, appliedConfig.entityIds, appliedConfig.showOnlyOn, optimisticStateValues, snapshot]);
 
   const onCount = lights.filter(isEntityOn).length;
   const visibleLights = lights.slice(0, isApp ? 24 : appliedConfig.maxItems || 10);
 
   const toggleLight = useCallback(async (entity: HomeAssistantEntity) => {
-    if (readOnly) return;
+    const action = getToggleAction(entity);
+    if (!action || readOnly) return;
+
+    setOptimisticState(entity.entityId, action.nextState);
+    setPendingEntity(entity.entityId, true);
 
     try {
-      setPendingEntityId(entity.entityId);
-      await callHomeAssistantService(appliedConfig, 'light', 'toggle', entity.entityId);
+      await callHomeAssistantService(appliedConfig, action.domain, action.service, entity.entityId);
       await refresh();
+    } catch (toggleError) {
+      clearOptimisticState(entity.entityId);
+      console.error('Failed to toggle Home Assistant light', toggleError);
     } finally {
-      setPendingEntityId(null);
+      setPendingEntity(entity.entityId, false);
     }
-  }, [appliedConfig, readOnly, refresh]);
+  }, [appliedConfig, clearOptimisticState, readOnly, refresh, setOptimisticState, setPendingEntity]);
 
   const resetSettings = () => {
     setDraftConfig(appliedConfig);
@@ -110,7 +128,7 @@ const HomeLightsWidget: React.FC<HomeLightsWidgetProps> = ({ width, height, conf
               type="button"
               size="sm"
               variant={isEntityOn(light) ? 'default' : 'outline'}
-              disabled={readOnly || pendingEntityId === light.entityId}
+              disabled={readOnly || pendingEntityIds.has(light.entityId)}
               onClick={() => toggleLight(light)}
               className="h-8 min-w-0 shrink truncate px-2 text-xs"
             >
@@ -134,7 +152,7 @@ const HomeLightsWidget: React.FC<HomeLightsWidgetProps> = ({ width, height, conf
               entity={light}
               dense={isCompact}
               action={readOnly ? undefined : () => toggleLight(light)}
-              actionDisabled={pendingEntityId === light.entityId}
+              actionDisabled={pendingEntityIds.has(light.entityId)}
             />
           ))}
         </div>

--- a/src/components/widgets/HomeOverviewWidget/index.tsx
+++ b/src/components/widgets/HomeOverviewWidget/index.tsx
@@ -13,11 +13,14 @@ import {
   HomeTinyStatus,
 } from '../homeAssistant/components';
 import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantOptimisticStates } from '../homeAssistant/optimisticEntityStates';
 import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
 import {
+  applyEntityStateOverrides,
   getHealthIssues,
   isActiveSecurityEntity,
   isEntityOn,
+  removeRedundantAggregateEntities,
   selectEntities,
   toPersistedHomeAssistantConfig,
 } from '../homeAssistant/utils';
@@ -42,13 +45,16 @@ const HomeOverviewWidget: React.FC<HomeOverviewWidgetProps> = ({ width, height, 
   const [draftConfig, setDraftConfig] = useState<HomeOverviewWidgetConfig>(appliedConfig);
   const [showSettings, setShowSettings] = useState(false);
   const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+  const { optimisticStateValues } = useHomeAssistantOptimisticStates(appliedConfig, snapshot);
 
   useEffect(() => {
     setDraftConfig(appliedConfig);
   }, [appliedConfig]);
 
   const summary = useMemo(() => {
-    const lights = selectEntities(snapshot, { domains: ['light'] });
+    const lights = removeRedundantAggregateEntities(
+      applyEntityStateOverrides(selectEntities(snapshot, { domains: ['light'] }), optimisticStateValues)
+    );
     const climate = selectEntities(snapshot, { domains: ['climate'] });
     const security = selectEntities(snapshot, { domains: ['lock', 'cover', 'binary_sensor', 'alarm_control_panel'] });
     const issues = getHealthIssues(snapshot, appliedConfig.batteryThreshold);
@@ -63,7 +69,7 @@ const HomeOverviewWidget: React.FC<HomeOverviewWidgetProps> = ({ width, height, 
       issues: issues.slice(0, isApp ? 12 : 5),
       entityCount: snapshot?.entities.length || 0,
     };
-  }, [appliedConfig.batteryThreshold, isApp, snapshot]);
+  }, [appliedConfig.batteryThreshold, isApp, optimisticStateValues, snapshot]);
 
   const resetSettings = () => {
     setDraftConfig(appliedConfig);

--- a/src/components/widgets/HomeRoomWidget/index.tsx
+++ b/src/components/widgets/HomeRoomWidget/index.tsx
@@ -15,13 +15,16 @@ import {
   HomeTinyStatus,
 } from '../homeAssistant/components';
 import { HomeAssistantSettingsDialog } from '../homeAssistant/settings';
+import { useHomeAssistantOptimisticStates } from '../homeAssistant/optimisticEntityStates';
 import { useHomeAssistantData } from '../homeAssistant/useHomeAssistantData';
 import {
   ROOM_DOMAINS,
+  applyEntityStateOverrides,
   canToggleEntity,
   getAreaName,
-  getToggleService,
+  getToggleAction,
   isEntityOn,
+  removeRedundantAggregateEntities,
   selectEntities,
   toPersistedHomeAssistantConfig,
 } from '../homeAssistant/utils';
@@ -48,8 +51,14 @@ const HomeRoomWidget: React.FC<HomeRoomWidgetProps> = ({ width, height, config }
   const appliedConfig = useMemo(() => ({ ...DEFAULT_CONFIG, ...config }), [config]);
   const [draftConfig, setDraftConfig] = useState<HomeRoomWidgetConfig>(appliedConfig);
   const [showSettings, setShowSettings] = useState(false);
-  const [pendingEntityId, setPendingEntityId] = useState<string | null>(null);
   const { snapshot, loading, refreshing, error, canFetch, refresh } = useHomeAssistantData(appliedConfig);
+  const {
+    optimisticStateValues,
+    pendingEntityIds,
+    setOptimisticState,
+    clearOptimisticState,
+    setPendingEntity,
+  } = useHomeAssistantOptimisticStates(appliedConfig, snapshot);
 
   useEffect(() => {
     setDraftConfig(appliedConfig);
@@ -58,29 +67,36 @@ const HomeRoomWidget: React.FC<HomeRoomWidgetProps> = ({ width, height, config }
   const roomEntities = useMemo(() => {
     const explicitAreaId = appliedConfig.areaId || inferPrimaryAreaId(snapshot);
 
-    return selectEntities(snapshot, {
+    const selected = selectEntities(snapshot, {
       domains: ROOM_DOMAINS,
       areaId: explicitAreaId,
       entityIds: appliedConfig.entityIds,
     });
-  }, [appliedConfig.areaId, appliedConfig.entityIds, snapshot]);
+
+    return removeRedundantAggregateEntities(applyEntityStateOverrides(selected, optimisticStateValues));
+  }, [appliedConfig.areaId, appliedConfig.entityIds, optimisticStateValues, snapshot]);
 
   const roomName = getAreaName(snapshot, appliedConfig.areaId || inferPrimaryAreaId(snapshot));
   const visibleEntities = roomEntities.slice(0, isApp ? 18 : appliedConfig.maxItems || 8);
   const activeCount = roomEntities.filter(isEntityOn).length;
 
   const toggleEntity = useCallback(async (entity: HomeAssistantEntity) => {
-    const service = getToggleService(entity);
-    if (!service || readOnly) return;
+    const action = getToggleAction(entity);
+    if (!action || readOnly) return;
+
+    setOptimisticState(entity.entityId, action.nextState);
+    setPendingEntity(entity.entityId, true);
 
     try {
-      setPendingEntityId(entity.entityId);
-      await callHomeAssistantService(appliedConfig, service.domain, service.service, entity.entityId);
+      await callHomeAssistantService(appliedConfig, action.domain, action.service, entity.entityId);
       await refresh();
+    } catch (toggleError) {
+      clearOptimisticState(entity.entityId);
+      console.error('Failed to toggle Home Assistant device', toggleError);
     } finally {
-      setPendingEntityId(null);
+      setPendingEntity(entity.entityId, false);
     }
-  }, [appliedConfig, readOnly, refresh]);
+  }, [appliedConfig, clearOptimisticState, readOnly, refresh, setOptimisticState, setPendingEntity]);
 
   const resetSettings = () => {
     setDraftConfig(appliedConfig);
@@ -129,7 +145,7 @@ const HomeRoomWidget: React.FC<HomeRoomWidgetProps> = ({ width, height, config }
               entity={entity}
               dense={isCompact}
               action={canToggleEntity(entity) && !readOnly ? () => toggleEntity(entity) : undefined}
-              actionDisabled={pendingEntityId === entity.entityId}
+              actionDisabled={pendingEntityIds.has(entity.entityId)}
             />
           ))}
         </div>

--- a/src/components/widgets/homeAssistant/client.ts
+++ b/src/components/widgets/homeAssistant/client.ts
@@ -188,8 +188,12 @@ function fetchRegistrySnapshotUncached(baseUrl: string, token: string): Promise<
 
     ws.addEventListener('message', (event) => {
       let message: Record<string, unknown>;
+      if (typeof event.data !== 'string') {
+        return;
+      }
+
       try {
-        message = JSON.parse(String(event.data));
+        message = JSON.parse(event.data);
       } catch {
         return;
       }

--- a/src/components/widgets/homeAssistant/client.ts
+++ b/src/components/widgets/homeAssistant/client.ts
@@ -163,7 +163,7 @@ function fetchRegistrySnapshotUncached(baseUrl: string, token: string): Promise<
     let nextId = 1;
     const results: RegistryResults = { ...EMPTY_REGISTRY };
     const pending = new Map<number, keyof RegistryResults>();
-    const ws = new WebSocket(createWebSocketUrl(baseUrl));
+    const ws = new WebSocket(createHomeAssistantWebSocketUrl(baseUrl));
 
     const finish = (value: RegistryResults) => {
       if (settled) return;
@@ -239,7 +239,7 @@ function getRegistryCacheDuration(value: RegistryResults): number {
   return hasRegistryData ? REGISTRY_CACHE_TTL_MS : EMPTY_REGISTRY_CACHE_TTL_MS;
 }
 
-function createWebSocketUrl(baseUrl: string): string {
+export function createHomeAssistantWebSocketUrl(baseUrl: string): string {
   const parsed = new URL(baseUrl);
   parsed.protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
   parsed.pathname = `${parsed.pathname.replace(/\/+$/, '')}/api/websocket`;

--- a/src/components/widgets/homeAssistant/optimisticEntityStates.ts
+++ b/src/components/widgets/homeAssistant/optimisticEntityStates.ts
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { normalizeHomeAssistantUrl } from './client';
+import type { HomeAssistantBaseConfig, HomeAssistantSnapshot } from './types';
+
+type OptimisticEntityState = {
+  state: string;
+  expiresAt: number;
+};
+
+const OPTIMISTIC_TOGGLE_TIMEOUT_MS = 10000;
+const DEFAULT_SCOPE = 'home-assistant';
+const optimisticStatesByScope = new Map<string, Map<string, OptimisticEntityState>>();
+const pendingEntityIdsByScope = new Map<string, Set<string>>();
+const listeners = new Set<() => void>();
+
+export function useHomeAssistantOptimisticStates(
+  config: HomeAssistantBaseConfig,
+  snapshot: HomeAssistantSnapshot | null
+) {
+  const scope = useMemo(() => getScopeKey(config.baseUrl), [config.baseUrl]);
+  const [version, setVersion] = useState(0);
+
+  useEffect(() => {
+    const listener = () => setVersion((current) => current + 1);
+    listeners.add(listener);
+
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const view = useMemo(() => {
+    void version;
+    return readScopeView(scope);
+  }, [scope, version]);
+
+  useEffect(() => {
+    if (!snapshot) return;
+    reconcileOptimisticStates(scope, snapshot);
+  }, [scope, snapshot]);
+
+  useEffect(() => {
+    if (view.optimisticCount === 0) return undefined;
+
+    const interval = window.setInterval(() => {
+      expireOptimisticStates(scope);
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [scope, view.optimisticCount]);
+
+  const setOptimisticState = useCallback((entityId: string, state: string) => {
+    setOptimisticEntityState(scope, entityId, state);
+  }, [scope]);
+
+  const clearOptimisticState = useCallback((entityId: string) => {
+    clearOptimisticEntityState(scope, entityId);
+  }, [scope]);
+
+  const setPendingEntity = useCallback((entityId: string, pending: boolean) => {
+    setPendingEntityState(scope, entityId, pending);
+  }, [scope]);
+
+  return {
+    optimisticStateValues: view.optimisticStateValues,
+    pendingEntityIds: view.pendingEntityIds,
+    setOptimisticState,
+    clearOptimisticState,
+    setPendingEntity,
+  };
+}
+
+function getScopeKey(baseUrl?: string): string {
+  return normalizeHomeAssistantUrl(baseUrl) || DEFAULT_SCOPE;
+}
+
+function readScopeView(scope: string): {
+  optimisticCount: number;
+  optimisticStateValues: Record<string, string>;
+  pendingEntityIds: Set<string>;
+} {
+  const optimisticStates = optimisticStatesByScope.get(scope);
+  const pendingEntityIds = pendingEntityIdsByScope.get(scope);
+
+  return {
+    optimisticCount: optimisticStates?.size || 0,
+    optimisticStateValues: Object.fromEntries(
+      [...(optimisticStates?.entries() || [])].map(([entityId, optimistic]) => [entityId, optimistic.state])
+    ),
+    pendingEntityIds: new Set(pendingEntityIds || []),
+  };
+}
+
+function setOptimisticEntityState(scope: string, entityId: string, state: string) {
+  const optimisticStates = getOptimisticStates(scope);
+  optimisticStates.set(entityId, {
+    state,
+    expiresAt: Date.now() + OPTIMISTIC_TOGGLE_TIMEOUT_MS,
+  });
+  emitChange();
+}
+
+function clearOptimisticEntityState(scope: string, entityId: string) {
+  const optimisticStates = optimisticStatesByScope.get(scope);
+  if (!optimisticStates?.delete(entityId)) return;
+
+  if (optimisticStates.size === 0) {
+    optimisticStatesByScope.delete(scope);
+  }
+
+  emitChange();
+}
+
+function setPendingEntityState(scope: string, entityId: string, pending: boolean) {
+  const pendingEntityIds = getPendingEntityIds(scope);
+
+  if (pending) {
+    pendingEntityIds.add(entityId);
+  } else {
+    pendingEntityIds.delete(entityId);
+  }
+
+  if (pendingEntityIds.size === 0) {
+    pendingEntityIdsByScope.delete(scope);
+  }
+
+  emitChange();
+}
+
+function reconcileOptimisticStates(scope: string, snapshot: HomeAssistantSnapshot) {
+  const optimisticStates = optimisticStatesByScope.get(scope);
+  if (!optimisticStates?.size) return;
+
+  const actualStates = new Map(snapshot.entities.map((entity) => [entity.entityId, entity.state]));
+  const now = Date.now();
+  let changed = false;
+
+  for (const [entityId, optimistic] of optimisticStates.entries()) {
+    if (actualStates.get(entityId) === optimistic.state || optimistic.expiresAt <= now) {
+      optimisticStates.delete(entityId);
+      changed = true;
+    }
+  }
+
+  if (optimisticStates.size === 0) {
+    optimisticStatesByScope.delete(scope);
+  }
+
+  if (changed) {
+    emitChange();
+  }
+}
+
+function expireOptimisticStates(scope: string) {
+  const optimisticStates = optimisticStatesByScope.get(scope);
+  if (!optimisticStates?.size) return;
+
+  const now = Date.now();
+  let changed = false;
+
+  for (const [entityId, optimistic] of optimisticStates.entries()) {
+    if (optimistic.expiresAt <= now) {
+      optimisticStates.delete(entityId);
+      changed = true;
+    }
+  }
+
+  if (optimisticStates.size === 0) {
+    optimisticStatesByScope.delete(scope);
+  }
+
+  if (changed) {
+    emitChange();
+  }
+}
+
+function getOptimisticStates(scope: string): Map<string, OptimisticEntityState> {
+  let optimisticStates = optimisticStatesByScope.get(scope);
+  if (!optimisticStates) {
+    optimisticStates = new Map();
+    optimisticStatesByScope.set(scope, optimisticStates);
+  }
+
+  return optimisticStates;
+}
+
+function getPendingEntityIds(scope: string): Set<string> {
+  let pendingEntityIds = pendingEntityIdsByScope.get(scope);
+  if (!pendingEntityIds) {
+    pendingEntityIds = new Set();
+    pendingEntityIdsByScope.set(scope, pendingEntityIds);
+  }
+
+  return pendingEntityIds;
+}
+
+function emitChange() {
+  listeners.forEach((listener) => listener());
+}

--- a/src/components/widgets/homeAssistant/optimisticEntityStates.ts
+++ b/src/components/widgets/homeAssistant/optimisticEntityStates.ts
@@ -12,23 +12,27 @@ const OPTIMISTIC_TOGGLE_TIMEOUT_MS = 10000;
 const DEFAULT_SCOPE = 'home-assistant';
 const optimisticStatesByScope = new Map<string, Map<string, OptimisticEntityState>>();
 const pendingEntityIdsByScope = new Map<string, Set<string>>();
-const listeners = new Set<() => void>();
+const listenersByScope = new Map<string, Set<() => void>>();
 
 export function useHomeAssistantOptimisticStates(
   config: HomeAssistantBaseConfig,
   snapshot: HomeAssistantSnapshot | null
 ) {
-  const scope = useMemo(() => getScopeKey(config.baseUrl), [config.baseUrl]);
+  const scope = useMemo(() => getScopeKey(config.baseUrl, config.apiToken), [config.apiToken, config.baseUrl]);
   const [version, setVersion] = useState(0);
 
   useEffect(() => {
     const listener = () => setVersion((current) => current + 1);
+    const listeners = getScopeListeners(scope);
     listeners.add(listener);
 
     return () => {
       listeners.delete(listener);
+      if (listeners.size === 0) {
+        listenersByScope.delete(scope);
+      }
     };
-  }, []);
+  }, [scope]);
 
   const view = useMemo(() => {
     void version;
@@ -71,8 +75,11 @@ export function useHomeAssistantOptimisticStates(
   };
 }
 
-function getScopeKey(baseUrl?: string): string {
-  return normalizeHomeAssistantUrl(baseUrl) || DEFAULT_SCOPE;
+function getScopeKey(baseUrlValue?: string, apiTokenValue?: string): string {
+  const baseUrl = normalizeHomeAssistantUrl(baseUrlValue);
+  const token = apiTokenValue?.trim();
+
+  return baseUrl && token ? `${baseUrl}::${token}` : DEFAULT_SCOPE;
 }
 
 function readScopeView(scope: string): {
@@ -98,7 +105,7 @@ function setOptimisticEntityState(scope: string, entityId: string, state: string
     state,
     expiresAt: Date.now() + OPTIMISTIC_TOGGLE_TIMEOUT_MS,
   });
-  emitChange();
+  emitScopeChange(scope);
 }
 
 function clearOptimisticEntityState(scope: string, entityId: string) {
@@ -109,7 +116,7 @@ function clearOptimisticEntityState(scope: string, entityId: string) {
     optimisticStatesByScope.delete(scope);
   }
 
-  emitChange();
+  emitScopeChange(scope);
 }
 
 function setPendingEntityState(scope: string, entityId: string, pending: boolean) {
@@ -125,7 +132,7 @@ function setPendingEntityState(scope: string, entityId: string, pending: boolean
     pendingEntityIdsByScope.delete(scope);
   }
 
-  emitChange();
+  emitScopeChange(scope);
 }
 
 function reconcileOptimisticStates(scope: string, snapshot: HomeAssistantSnapshot) {
@@ -148,7 +155,7 @@ function reconcileOptimisticStates(scope: string, snapshot: HomeAssistantSnapsho
   }
 
   if (changed) {
-    emitChange();
+    emitScopeChange(scope);
   }
 }
 
@@ -171,7 +178,7 @@ function expireOptimisticStates(scope: string) {
   }
 
   if (changed) {
-    emitChange();
+    emitScopeChange(scope);
   }
 }
 
@@ -195,6 +202,16 @@ function getPendingEntityIds(scope: string): Set<string> {
   return pendingEntityIds;
 }
 
-function emitChange() {
-  listeners.forEach((listener) => listener());
+function getScopeListeners(scope: string): Set<() => void> {
+  let listeners = listenersByScope.get(scope);
+  if (!listeners) {
+    listeners = new Set();
+    listenersByScope.set(scope, listeners);
+  }
+
+  return listeners;
+}
+
+function emitScopeChange(scope: string) {
+  listenersByScope.get(scope)?.forEach((listener) => listener());
 }

--- a/src/components/widgets/homeAssistant/useHomeAssistantData.ts
+++ b/src/components/widgets/homeAssistant/useHomeAssistantData.ts
@@ -1,65 +1,399 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { fetchHomeAssistantSnapshot } from './client';
-import type { HomeAssistantBaseConfig, HomeAssistantSnapshot } from './types';
+import { createHomeAssistantWebSocketUrl, fetchHomeAssistantSnapshot, normalizeHomeAssistantUrl } from './client';
+import type { HomeAssistantBaseConfig, HomeAssistantSnapshot, HomeAssistantState } from './types';
+import { patchHomeAssistantSnapshotState } from './utils';
+
+type FetchMode = 'initial' | 'refresh';
+type RealtimeStatus = 'idle' | 'connecting' | 'connected';
+
+type HomeAssistantWebSocketMessage = {
+  event?: {
+    data?: {
+      new_state?: unknown;
+    };
+    event_type?: string;
+  };
+  id?: number;
+  success?: boolean;
+  type?: string;
+};
+
+type SharedHomeAssistantData = {
+  config: HomeAssistantBaseConfig;
+  error: string | null;
+  intervalId?: number;
+  loading: boolean;
+  promise?: Promise<void>;
+  realtimeMessageId: number;
+  realtimePingTimerId?: number;
+  realtimeReconnectAttempts: number;
+  realtimeReconnectTimerId?: number;
+  realtimeSocket?: WebSocket;
+  realtimeStatus: RealtimeStatus;
+  realtimeSubscriptionId?: number;
+  refreshIntervalMs: number;
+  refreshing: boolean;
+  snapshot: HomeAssistantSnapshot | null;
+  subscribers: Set<() => void>;
+};
 
 const DEFAULT_REFRESH_INTERVAL = 30;
+const FETCH_TIMEOUT_MS = 12000;
+const REALTIME_PING_INTERVAL_MS = 30000;
+const REALTIME_RECONNECT_BASE_MS = 1000;
+const REALTIME_RECONNECT_MAX_MS = 30000;
+const sharedDataByConnection = new Map<string, SharedHomeAssistantData>();
 
 export function useHomeAssistantData(config: HomeAssistantBaseConfig) {
-  const [snapshot, setSnapshot] = useState<HomeAssistantSnapshot | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const canFetch = Boolean(config.baseUrl?.trim() && config.apiToken?.trim());
-  const refreshInterval = Math.max(10, Number(config.refreshInterval || DEFAULT_REFRESH_INTERVAL));
-
-  const fetchData = useCallback(async (mode: 'initial' | 'refresh' = 'refresh') => {
-    if (!canFetch) {
-      setSnapshot(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-
-    const controller = new AbortController();
-    const timeout = window.setTimeout(() => controller.abort(), 12000);
-
-    try {
-      if (mode === 'initial') {
-        setLoading(true);
-      } else {
-        setRefreshing(true);
-      }
-      setError(null);
-      const nextSnapshot = await fetchHomeAssistantSnapshot(config, controller.signal);
-      setSnapshot(nextSnapshot);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load Home Assistant');
-    } finally {
-      window.clearTimeout(timeout);
-      setLoading(false);
-      setRefreshing(false);
-    }
-  }, [canFetch, config]);
+  const { apiToken, baseUrl, refreshInterval } = config;
+  const canFetch = Boolean(baseUrl?.trim() && apiToken?.trim());
+  const connectionKey = useMemo(() => getConnectionKey(baseUrl, apiToken), [apiToken, baseUrl]);
+  const refreshIntervalMs = Math.max(10, Number(refreshInterval || DEFAULT_REFRESH_INTERVAL)) * 1000;
+  const [version, setVersion] = useState(0);
 
   useEffect(() => {
-    fetchData('initial');
-    if (!canFetch) return undefined;
+    if (!canFetch || !connectionKey) return undefined;
 
-    const interval = window.setInterval(() => {
-      fetchData('refresh');
-    }, refreshInterval * 1000);
+    const entry = getSharedData(connectionKey, config, refreshIntervalMs);
+    entry.config = config;
+    entry.refreshIntervalMs = refreshIntervalMs;
 
-    return () => window.clearInterval(interval);
-  }, [canFetch, fetchData, refreshInterval]);
+    const listener = () => setVersion((current) => current + 1);
+    entry.subscribers.add(listener);
+    ensureRefreshInterval(entry);
+    ensureRealtimeConnection(entry);
+
+    if (!entry.snapshot && !entry.promise) {
+      void fetchSharedData(entry, 'initial');
+    }
+
+    return () => {
+      entry.subscribers.delete(listener);
+
+      if (entry.subscribers.size === 0 && entry.intervalId !== undefined) {
+        window.clearInterval(entry.intervalId);
+        entry.intervalId = undefined;
+      }
+
+      if (entry.subscribers.size === 0) {
+        disconnectRealtime(entry);
+      }
+    };
+  }, [canFetch, config, connectionKey, refreshIntervalMs]);
+
+  const view = useMemo(() => {
+    void version;
+
+    if (!canFetch || !connectionKey) {
+      return {
+        error: null,
+        loading: false,
+        refreshing: false,
+        snapshot: null,
+      };
+    }
+
+    const entry = getSharedData(connectionKey, config, refreshIntervalMs);
+    return {
+      error: entry.error,
+      loading: entry.loading,
+      refreshing: entry.refreshing,
+      snapshot: entry.snapshot,
+    };
+  }, [canFetch, config, connectionKey, refreshIntervalMs, version]);
+
+  const refresh = useCallback(() => {
+    if (!canFetch || !connectionKey) {
+      return Promise.resolve();
+    }
+
+    const entry = getSharedData(connectionKey, config, refreshIntervalMs);
+    entry.config = config;
+    return fetchSharedData(entry, 'refresh');
+  }, [canFetch, config, connectionKey, refreshIntervalMs]);
 
   return useMemo(() => ({
-    snapshot,
-    loading,
-    refreshing,
-    error,
+    snapshot: view.snapshot,
+    loading: view.loading,
+    refreshing: view.refreshing,
+    error: view.error,
     canFetch,
-    refresh: () => fetchData('refresh'),
-  }), [canFetch, error, fetchData, loading, refreshing, snapshot]);
+    refresh,
+  }), [canFetch, refresh, view.error, view.loading, view.refreshing, view.snapshot]);
+}
+
+function getConnectionKey(baseUrlValue?: string, apiTokenValue?: string): string {
+  const baseUrl = normalizeHomeAssistantUrl(baseUrlValue);
+  const token = apiTokenValue?.trim();
+
+  return baseUrl && token ? `${baseUrl}::${token}` : '';
+}
+
+function getSharedData(
+  connectionKey: string,
+  config: HomeAssistantBaseConfig,
+  refreshIntervalMs: number
+): SharedHomeAssistantData {
+  const existing = sharedDataByConnection.get(connectionKey);
+  if (existing) return existing;
+
+  const next: SharedHomeAssistantData = {
+    config,
+    error: null,
+    loading: true,
+    realtimeMessageId: 1,
+    realtimeReconnectAttempts: 0,
+    realtimeStatus: 'idle',
+    refreshIntervalMs,
+    refreshing: false,
+    snapshot: null,
+    subscribers: new Set(),
+  };
+  sharedDataByConnection.set(connectionKey, next);
+
+  return next;
+}
+
+function ensureRefreshInterval(entry: SharedHomeAssistantData) {
+  if (entry.intervalId !== undefined) {
+    window.clearInterval(entry.intervalId);
+  }
+
+  entry.intervalId = window.setInterval(() => {
+    void fetchSharedData(entry, 'refresh');
+  }, entry.refreshIntervalMs);
+}
+
+function ensureRealtimeConnection(entry: SharedHomeAssistantData) {
+  const baseUrl = normalizeHomeAssistantUrl(entry.config.baseUrl);
+  const token = entry.config.apiToken?.trim();
+
+  if (!baseUrl || !token) return;
+  if (entry.realtimeSocket || entry.realtimeStatus !== 'idle' || entry.realtimeReconnectTimerId !== undefined) return;
+
+  connectRealtime(entry, baseUrl, token);
+}
+
+function connectRealtime(entry: SharedHomeAssistantData, baseUrl: string, token: string) {
+  let socket: WebSocket;
+
+  try {
+    socket = new WebSocket(createHomeAssistantWebSocketUrl(baseUrl));
+  } catch {
+    scheduleRealtimeReconnect(entry);
+    return;
+  }
+
+  entry.realtimeSocket = socket;
+  entry.realtimeStatus = 'connecting';
+
+  socket.addEventListener('message', (event) => {
+    handleRealtimeMessage(entry, socket, token, event);
+  });
+
+  socket.addEventListener('error', () => {
+    if (entry.realtimeSocket !== socket) return;
+
+    try {
+      socket.close();
+    } catch {
+      scheduleRealtimeReconnect(entry);
+    }
+  });
+
+  socket.addEventListener('close', () => {
+    handleRealtimeClose(entry, socket);
+  });
+}
+
+function handleRealtimeMessage(
+  entry: SharedHomeAssistantData,
+  socket: WebSocket,
+  token: string,
+  event: MessageEvent
+) {
+  let message: HomeAssistantWebSocketMessage;
+
+  try {
+    message = JSON.parse(String(event.data)) as HomeAssistantWebSocketMessage;
+  } catch {
+    return;
+  }
+
+  if (message.type === 'auth_required') {
+    sendSocketMessage(socket, { type: 'auth', access_token: token });
+    return;
+  }
+
+  if (message.type === 'auth_invalid') {
+    entry.error = 'Home Assistant rejected the access token';
+    emitChange(entry);
+    disconnectRealtime(entry);
+    return;
+  }
+
+  if (message.type === 'auth_ok') {
+    entry.realtimeStatus = 'connected';
+    entry.realtimeReconnectAttempts = 0;
+    entry.realtimeSubscriptionId = sendRealtimeCommand(entry, socket, {
+      type: 'subscribe_events',
+      event_type: 'state_changed',
+    });
+    startRealtimeHeartbeat(entry, socket);
+    return;
+  }
+
+  if (message.type === 'result' && message.id === entry.realtimeSubscriptionId && message.success === false) {
+    disconnectRealtime(entry);
+    scheduleRealtimeReconnect(entry);
+    return;
+  }
+
+  if (message.type !== 'event' || message.event?.event_type !== 'state_changed') {
+    return;
+  }
+
+  const nextState = message.event.data?.new_state;
+  if (!entry.snapshot || !isHomeAssistantState(nextState)) {
+    return;
+  }
+
+  entry.snapshot = patchHomeAssistantSnapshotState(entry.snapshot, nextState);
+  entry.error = null;
+  emitChange(entry);
+}
+
+function handleRealtimeClose(entry: SharedHomeAssistantData, socket: WebSocket) {
+  if (entry.realtimeSocket !== socket) return;
+
+  stopRealtimeHeartbeat(entry);
+  entry.realtimeSocket = undefined;
+  entry.realtimeStatus = 'idle';
+  entry.realtimeSubscriptionId = undefined;
+  scheduleRealtimeReconnect(entry);
+}
+
+function startRealtimeHeartbeat(entry: SharedHomeAssistantData, socket: WebSocket) {
+  stopRealtimeHeartbeat(entry);
+
+  entry.realtimePingTimerId = window.setInterval(() => {
+    if (entry.realtimeSocket !== socket || socket.readyState !== WebSocket.OPEN) return;
+
+    sendRealtimeCommand(entry, socket, { type: 'ping' });
+  }, REALTIME_PING_INTERVAL_MS);
+}
+
+function stopRealtimeHeartbeat(entry: SharedHomeAssistantData) {
+  if (entry.realtimePingTimerId === undefined) return;
+
+  window.clearInterval(entry.realtimePingTimerId);
+  entry.realtimePingTimerId = undefined;
+}
+
+function scheduleRealtimeReconnect(entry: SharedHomeAssistantData) {
+  if (entry.subscribers.size === 0 || entry.realtimeReconnectTimerId !== undefined) return;
+
+  const delay = Math.min(
+    REALTIME_RECONNECT_MAX_MS,
+    REALTIME_RECONNECT_BASE_MS * 2 ** entry.realtimeReconnectAttempts
+  );
+  entry.realtimeReconnectAttempts += 1;
+  entry.realtimeReconnectTimerId = window.setTimeout(() => {
+    entry.realtimeReconnectTimerId = undefined;
+    ensureRealtimeConnection(entry);
+  }, delay);
+}
+
+function disconnectRealtime(entry: SharedHomeAssistantData) {
+  if (entry.realtimeReconnectTimerId !== undefined) {
+    window.clearTimeout(entry.realtimeReconnectTimerId);
+    entry.realtimeReconnectTimerId = undefined;
+  }
+
+  stopRealtimeHeartbeat(entry);
+
+  const socket = entry.realtimeSocket;
+  entry.realtimeSocket = undefined;
+  entry.realtimeStatus = 'idle';
+  entry.realtimeSubscriptionId = undefined;
+  entry.realtimeReconnectAttempts = 0;
+
+  if (!socket) return;
+
+  try {
+    socket.close();
+  } catch {
+    // The socket may already be closing.
+  }
+}
+
+function sendRealtimeCommand(
+  entry: SharedHomeAssistantData,
+  socket: WebSocket,
+  message: Record<string, unknown>
+): number {
+  const id = entry.realtimeMessageId;
+  entry.realtimeMessageId += 1;
+  sendSocketMessage(socket, { id, ...message });
+
+  return id;
+}
+
+function sendSocketMessage(socket: WebSocket, message: Record<string, unknown>) {
+  if (socket.readyState !== WebSocket.OPEN) return;
+
+  socket.send(JSON.stringify(message));
+}
+
+function isHomeAssistantState(value: unknown): value is HomeAssistantState {
+  if (!value || typeof value !== 'object') return false;
+
+  const state = value as Partial<HomeAssistantState>;
+  return (
+    typeof state.entity_id === 'string' &&
+    typeof state.state === 'string' &&
+    Boolean(state.attributes) &&
+    typeof state.attributes === 'object'
+  );
+}
+
+async function fetchSharedData(entry: SharedHomeAssistantData, mode: FetchMode): Promise<void> {
+  if (entry.promise) {
+    return entry.promise;
+  }
+
+  const fetchPromise = fetchSharedDataUncached(entry, mode);
+  entry.promise = fetchPromise;
+
+  return fetchPromise;
+}
+
+async function fetchSharedDataUncached(entry: SharedHomeAssistantData, mode: FetchMode): Promise<void> {
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    if (mode === 'initial' && !entry.snapshot) {
+      entry.loading = true;
+    } else {
+      entry.refreshing = true;
+    }
+    entry.error = null;
+    emitChange(entry);
+
+    entry.snapshot = await fetchHomeAssistantSnapshot(entry.config, controller.signal);
+  } catch (err) {
+    entry.error = err instanceof Error ? err.message : 'Failed to load Home Assistant';
+  } finally {
+    window.clearTimeout(timeout);
+    entry.loading = false;
+    entry.refreshing = false;
+    entry.promise = undefined;
+    emitChange(entry);
+  }
+}
+
+function emitChange(entry: SharedHomeAssistantData) {
+  entry.subscribers.forEach((listener) => listener());
 }

--- a/src/components/widgets/homeAssistant/useHomeAssistantData.ts
+++ b/src/components/widgets/homeAssistant/useHomeAssistantData.ts
@@ -22,6 +22,7 @@ type HomeAssistantWebSocketMessage = {
 type SharedHomeAssistantData = {
   config: HomeAssistantBaseConfig;
   error: string | null;
+  intervalDelayMs?: number;
   intervalId?: number;
   loading: boolean;
   promise?: Promise<void>;
@@ -32,9 +33,9 @@ type SharedHomeAssistantData = {
   realtimeSocket?: WebSocket;
   realtimeStatus: RealtimeStatus;
   realtimeSubscriptionId?: number;
-  refreshIntervalMs: number;
   refreshing: boolean;
   snapshot: HomeAssistantSnapshot | null;
+  subscriberRefreshIntervals: Map<() => void, number>;
   subscribers: Set<() => void>;
 };
 
@@ -55,12 +56,12 @@ export function useHomeAssistantData(config: HomeAssistantBaseConfig) {
   useEffect(() => {
     if (!canFetch || !connectionKey) return undefined;
 
-    const entry = getSharedData(connectionKey, config, refreshIntervalMs);
+    const entry = getSharedData(connectionKey, config);
     entry.config = config;
-    entry.refreshIntervalMs = refreshIntervalMs;
 
     const listener = () => setVersion((current) => current + 1);
     entry.subscribers.add(listener);
+    entry.subscriberRefreshIntervals.set(listener, refreshIntervalMs);
     ensureRefreshInterval(entry);
     ensureRealtimeConnection(entry);
 
@@ -70,14 +71,19 @@ export function useHomeAssistantData(config: HomeAssistantBaseConfig) {
 
     return () => {
       entry.subscribers.delete(listener);
+      entry.subscriberRefreshIntervals.delete(listener);
 
       if (entry.subscribers.size === 0 && entry.intervalId !== undefined) {
         window.clearInterval(entry.intervalId);
         entry.intervalId = undefined;
+        entry.intervalDelayMs = undefined;
       }
 
       if (entry.subscribers.size === 0) {
         disconnectRealtime(entry);
+        sharedDataByConnection.delete(connectionKey);
+      } else {
+        ensureRefreshInterval(entry);
       }
     };
   }, [canFetch, config, connectionKey, refreshIntervalMs]);
@@ -94,24 +100,24 @@ export function useHomeAssistantData(config: HomeAssistantBaseConfig) {
       };
     }
 
-    const entry = getSharedData(connectionKey, config, refreshIntervalMs);
+    const entry = getSharedData(connectionKey, config);
     return {
       error: entry.error,
       loading: entry.loading,
       refreshing: entry.refreshing,
       snapshot: entry.snapshot,
     };
-  }, [canFetch, config, connectionKey, refreshIntervalMs, version]);
+  }, [canFetch, config, connectionKey, version]);
 
   const refresh = useCallback(() => {
     if (!canFetch || !connectionKey) {
       return Promise.resolve();
     }
 
-    const entry = getSharedData(connectionKey, config, refreshIntervalMs);
+    const entry = getSharedData(connectionKey, config);
     entry.config = config;
     return fetchSharedData(entry, 'refresh');
-  }, [canFetch, config, connectionKey, refreshIntervalMs]);
+  }, [canFetch, config, connectionKey]);
 
   return useMemo(() => ({
     snapshot: view.snapshot,
@@ -130,11 +136,7 @@ function getConnectionKey(baseUrlValue?: string, apiTokenValue?: string): string
   return baseUrl && token ? `${baseUrl}::${token}` : '';
 }
 
-function getSharedData(
-  connectionKey: string,
-  config: HomeAssistantBaseConfig,
-  refreshIntervalMs: number
-): SharedHomeAssistantData {
+function getSharedData(connectionKey: string, config: HomeAssistantBaseConfig): SharedHomeAssistantData {
   const existing = sharedDataByConnection.get(connectionKey);
   if (existing) return existing;
 
@@ -145,9 +147,9 @@ function getSharedData(
     realtimeMessageId: 1,
     realtimeReconnectAttempts: 0,
     realtimeStatus: 'idle',
-    refreshIntervalMs,
     refreshing: false,
     snapshot: null,
+    subscriberRefreshIntervals: new Map(),
     subscribers: new Set(),
   };
   sharedDataByConnection.set(connectionKey, next);
@@ -156,13 +158,24 @@ function getSharedData(
 }
 
 function ensureRefreshInterval(entry: SharedHomeAssistantData) {
+  const intervalDelayMs = getSharedRefreshIntervalMs(entry);
+  if (entry.intervalId !== undefined && entry.intervalDelayMs === intervalDelayMs) {
+    return;
+  }
+
   if (entry.intervalId !== undefined) {
     window.clearInterval(entry.intervalId);
   }
 
+  entry.intervalDelayMs = intervalDelayMs;
   entry.intervalId = window.setInterval(() => {
     void fetchSharedData(entry, 'refresh');
-  }, entry.refreshIntervalMs);
+  }, intervalDelayMs);
+}
+
+function getSharedRefreshIntervalMs(entry: SharedHomeAssistantData): number {
+  const intervals = [...entry.subscriberRefreshIntervals.values()];
+  return intervals.length ? Math.min(...intervals) : DEFAULT_REFRESH_INTERVAL * 1000;
 }
 
 function ensureRealtimeConnection(entry: SharedHomeAssistantData) {
@@ -215,8 +228,12 @@ function handleRealtimeMessage(
 ) {
   let message: HomeAssistantWebSocketMessage;
 
+  if (typeof event.data !== 'string') {
+    return;
+  }
+
   try {
-    message = JSON.parse(String(event.data)) as HomeAssistantWebSocketMessage;
+    message = JSON.parse(event.data) as HomeAssistantWebSocketMessage;
   } catch {
     return;
   }

--- a/src/components/widgets/homeAssistant/utils.ts
+++ b/src/components/widgets/homeAssistant/utils.ts
@@ -153,14 +153,30 @@ export function patchHomeAssistantSnapshotState(
     states.push(nextState);
   }
 
+  const registryEntry = snapshot.registryEntities.find((entity) => entity.entity_id === nextState.entity_id);
+  const entities = found
+    ? snapshot.entities.map((entity) => entity.entityId === nextState.entity_id
+      ? {
+          ...entity,
+          name: getEntityName(nextState, registryEntry),
+          state: nextState.state,
+          attributes: nextState.attributes,
+          deviceClass: getStringAttribute(nextState, 'device_class'),
+          unit: getStringAttribute(nextState, 'unit_of_measurement'),
+          lastChanged: nextState.last_changed,
+          lastUpdated: nextState.last_updated,
+        }
+      : entity)
+    : buildHomeAssistantEntities(states, {
+        areas: snapshot.areas,
+        devices: snapshot.devices,
+        entities: snapshot.registryEntities,
+      });
+
   return {
     ...snapshot,
     states,
-    entities: buildHomeAssistantEntities(states, {
-      areas: snapshot.areas,
-      devices: snapshot.devices,
-      entities: snapshot.registryEntities,
-    }),
+    entities,
     loadedAt: new Date().toISOString(),
   };
 }

--- a/src/components/widgets/homeAssistant/utils.ts
+++ b/src/components/widgets/homeAssistant/utils.ts
@@ -12,6 +12,7 @@ const UNAVAILABLE_STATES = new Set(['unavailable', 'unknown']);
 const ON_STATES = new Set(['on', 'open', 'opening', 'unlocked', 'home', 'heat', 'cool', 'heat_cool', 'playing']);
 const LOW_BATTERY_CLASSES = new Set(['battery']);
 const OPEN_SECURITY_STATES = new Set(['open', 'unlocked', 'triggered']);
+const ENTITY_NAME_COLLATOR = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
 export const LIGHT_DOMAINS = ['light'];
 export const CLIMATE_DOMAINS = ['climate', 'fan', 'humidifier'];
@@ -102,7 +103,7 @@ export function selectEntities(
     .filter((entity) => domains.size === 0 || domains.has(entity.domain))
     .filter((entity) => !options.areaId || entity.areaId === options.areaId)
     .filter((entity) => selectedIds.size === 0 || selectedIds.has(entity.entityId))
-    .sort((a, b) => getEntitySortRank(a) - getEntitySortRank(b) || a.name.localeCompare(b.name));
+    .sort((a, b) => ENTITY_NAME_COLLATOR.compare(a.name, b.name) || a.entityId.localeCompare(b.entityId));
 }
 
 export function getAreaName(snapshot: HomeAssistantSnapshot | null, areaId?: string): string {
@@ -118,6 +119,61 @@ export function isEntityOn(entity: HomeAssistantEntity): boolean {
   return ON_STATES.has(entity.state);
 }
 
+export type HomeAssistantEntityStateOverrides = Record<string, string>;
+
+export function applyEntityStateOverrides(
+  entities: HomeAssistantEntity[],
+  overrides: HomeAssistantEntityStateOverrides
+): HomeAssistantEntity[] {
+  if (Object.keys(overrides).length === 0) {
+    return entities;
+  }
+
+  return entities.map((entity) => {
+    const nextState = overrides[entity.entityId];
+    return nextState ? { ...entity, state: nextState } : entity;
+  });
+}
+
+export function patchHomeAssistantSnapshotState(
+  snapshot: HomeAssistantSnapshot,
+  nextState: HomeAssistantState
+): HomeAssistantSnapshot {
+  let found = false;
+  const states = snapshot.states.map((state) => {
+    if (state.entity_id !== nextState.entity_id) {
+      return state;
+    }
+
+    found = true;
+    return nextState;
+  });
+
+  if (!found) {
+    states.push(nextState);
+  }
+
+  return {
+    ...snapshot,
+    states,
+    entities: buildHomeAssistantEntities(states, {
+      areas: snapshot.areas,
+      devices: snapshot.devices,
+      entities: snapshot.registryEntities,
+    }),
+    loadedAt: new Date().toISOString(),
+  };
+}
+
+export function removeRedundantAggregateEntities(entities: HomeAssistantEntity[]): HomeAssistantEntity[] {
+  const selectedEntityIds = new Set(entities.map((entity) => entity.entityId));
+
+  return entities.filter((entity) => {
+    const groupedEntityIds = getGroupedEntityIds(entity);
+    return groupedEntityIds.length === 0 || !groupedEntityIds.some((entityId) => selectedEntityIds.has(entityId));
+  });
+}
+
 export function isActiveSecurityEntity(entity: HomeAssistantEntity): boolean {
   return OPEN_SECURITY_STATES.has(entity.state) || (entity.domain === 'binary_sensor' && isEntityOn(entity));
 }
@@ -126,20 +182,44 @@ export function canToggleEntity(entity: HomeAssistantEntity): boolean {
   return ['light', 'switch', 'fan', 'cover', 'lock', 'input_boolean'].includes(entity.domain);
 }
 
-export function getToggleService(entity: HomeAssistantEntity): { domain: string; service: string } | null {
+export function getToggleAction(entity: HomeAssistantEntity): { domain: string; service: string; nextState: string } | null {
   if (entity.domain === 'cover') {
-    return { domain: 'cover', service: entity.state === 'open' ? 'close_cover' : 'open_cover' };
+    const shouldClose = entity.state === 'open' || entity.state === 'opening';
+    return {
+      domain: 'cover',
+      service: shouldClose ? 'close_cover' : 'open_cover',
+      nextState: shouldClose ? 'closed' : 'open',
+    };
   }
 
   if (entity.domain === 'lock') {
-    return { domain: 'lock', service: entity.state === 'unlocked' ? 'lock' : 'unlock' };
+    const shouldLock = entity.state === 'unlocked';
+    return {
+      domain: 'lock',
+      service: shouldLock ? 'lock' : 'unlock',
+      nextState: shouldLock ? 'locked' : 'unlocked',
+    };
   }
 
   if (['light', 'switch', 'fan', 'input_boolean'].includes(entity.domain)) {
-    return { domain: entity.domain, service: 'toggle' };
+    const shouldTurnOff = isEntityOn(entity);
+    return {
+      domain: entity.domain,
+      service: shouldTurnOff ? 'turn_off' : 'turn_on',
+      nextState: shouldTurnOff ? 'off' : 'on',
+    };
   }
 
   return null;
+}
+
+export function getToggleService(entity: HomeAssistantEntity): { domain: string; service: string } | null {
+  const action = getToggleAction(entity);
+  return action ? { domain: action.domain, service: action.service } : null;
+}
+
+export function getOptimisticToggleState(entity: HomeAssistantEntity): string {
+  return getToggleAction(entity)?.nextState || entity.state;
 }
 
 export function getClimateTemperature(entity: HomeAssistantEntity): number | null {
@@ -252,10 +332,14 @@ function isDiagnosticEntity(entity: HomeAssistantEntity): boolean {
   return entity.entityCategory === 'diagnostic' || entity.entityCategory === 'config';
 }
 
-function getEntitySortRank(entity: HomeAssistantEntity): number {
-  if (isEntityOn(entity)) return 0;
-  if (isUnavailable(entity)) return 2;
-  return 1;
+function getGroupedEntityIds(entity: HomeAssistantEntity): string[] {
+  const groupedEntityIds = entity.attributes.entity_id;
+
+  if (Array.isArray(groupedEntityIds)) {
+    return groupedEntityIds.filter((entityId): entityId is string => typeof entityId === 'string');
+  }
+
+  return typeof groupedEntityIds === 'string' ? [groupedEntityIds] : [];
 }
 
 function severityRank(severity: HomeAssistantHealthIssue['severity']): number {

--- a/src/lib/configManager.ts
+++ b/src/lib/configManager.ts
@@ -89,13 +89,26 @@ export const configManager = {
       const decryptedConfigs: WidgetConfigStore = {};
 
       for (const widgetId of Object.keys(configs)) {
-        const decryptedConfig = await encryptionUtils.processObjectFromStorage(
-          configs[widgetId],
-          DEFAULT_SENSITIVE_FIELDS
-        );
+        try {
+          const decryptedConfig = await encryptionUtils.processObjectFromStorage(
+            configs[widgetId],
+            DEFAULT_SENSITIVE_FIELDS
+          );
 
-        // Restore Date objects
-        decryptedConfigs[widgetId] = configManager.restoreDates(decryptedConfig);
+          // Restore Date objects
+          decryptedConfigs[widgetId] = configManager.restoreDates(decryptedConfig);
+        } catch (error) {
+          console.warn(`Skipping undecryptable sensitive fields for widget config "${widgetId}"`, error);
+
+          const fallbackConfig = { ...configs[widgetId] };
+          for (const field of DEFAULT_SENSITIVE_FIELDS) {
+            if (typeof fallbackConfig[field] === 'string' && (fallbackConfig[field] as string).startsWith('enc:v1:')) {
+              delete fallbackConfig[field];
+            }
+          }
+
+          decryptedConfigs[widgetId] = configManager.restoreDates(fallbackConfig);
+        }
       }
 
       return decryptedConfigs;

--- a/tests/unit/homeAssistantUtils.test.ts
+++ b/tests/unit/homeAssistantUtils.test.ts
@@ -190,6 +190,7 @@ describe('Home Assistant widget utilities', () => {
         entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
       }),
     };
+    const originalRemoteBattery = snapshot.entities.find((entity) => entity.entityId === 'sensor.remote_battery');
 
     const patched = patchHomeAssistantSnapshotState(snapshot, {
       entity_id: 'light.kitchen',
@@ -198,6 +199,7 @@ describe('Home Assistant widget utilities', () => {
     });
 
     expect(patched.states.find((state) => state.entity_id === 'light.kitchen')?.state).toBe('off');
+    expect(patched.entities.find((entity) => entity.entityId === 'sensor.remote_battery')).toBe(originalRemoteBattery);
     expect(patched.entities.find((entity) => entity.entityId === 'light.kitchen')).toMatchObject({
       areaId: 'kitchen',
       areaName: 'Kitchen',

--- a/tests/unit/homeAssistantUtils.test.ts
+++ b/tests/unit/homeAssistantUtils.test.ts
@@ -6,8 +6,11 @@ import {
   formatTemperatureValue,
   getHealthIssues,
   getTemperatureUnit,
+  getToggleAction,
   isActiveSecurityEntity,
+  patchHomeAssistantSnapshotState,
   parseEntityIds,
+  removeRedundantAggregateEntities,
   selectEntities,
 } from '@/components/widgets/homeAssistant/utils';
 
@@ -103,25 +106,122 @@ describe('Home Assistant widget utilities', () => {
     ]);
   });
 
-  it('sorts active entities before idle and unavailable entities', () => {
+  it('keeps entity ordering stable across state changes', () => {
+    const orderedStates: HomeAssistantState[] = [
+      {
+        entity_id: 'light.hue_candle_2',
+        state: 'on',
+        attributes: { friendly_name: 'Hue candle 2' },
+      },
+      {
+        entity_id: 'light.hue_candle_10',
+        state: 'off',
+        attributes: { friendly_name: 'Hue candle 10' },
+      },
+      {
+        entity_id: 'light.hue_candle_1',
+        state: 'off',
+        attributes: { friendly_name: 'Hue candle 1' },
+      },
+    ];
     const snapshot = {
       loadedAt: new Date().toISOString(),
-      states,
+      states: orderedStates,
       areas: [],
       devices: [],
       registryEntities: [],
-      entities: buildHomeAssistantEntities(states, {
+      entities: buildHomeAssistantEntities(orderedStates, {
         areas: [],
         devices: [],
         entities: [],
       }),
     };
 
-    expect(selectEntities(snapshot, { domains: ['light', 'switch'] }).map((entity) => entity.entityId)).toEqual([
-      'light.kitchen',
-      'light.living_room',
-      'switch.router',
+    expect(selectEntities(snapshot, { domains: ['light'] }).map((entity) => entity.entityId)).toEqual([
+      'light.hue_candle_1',
+      'light.hue_candle_2',
+      'light.hue_candle_10',
     ]);
+  });
+
+  it('removes aggregate entities when their members are already present', () => {
+    const groupStates: HomeAssistantState[] = [
+      {
+        entity_id: 'light.hue_candle_1',
+        state: 'off',
+        attributes: { friendly_name: 'Hue candle 1' },
+      },
+      {
+        entity_id: 'light.hue_candle_2',
+        state: 'off',
+        attributes: { friendly_name: 'Hue candle 2' },
+      },
+      {
+        entity_id: 'light.living_room',
+        state: 'off',
+        attributes: {
+          friendly_name: 'Living room',
+          entity_id: ['light.hue_candle_1', 'light.hue_candle_2'],
+        },
+      },
+    ];
+    const entities = buildHomeAssistantEntities(groupStates, {
+      areas: [],
+      devices: [],
+      entities: [],
+    });
+
+    expect(removeRedundantAggregateEntities(entities).map((entity) => entity.entityId)).toEqual([
+      'light.hue_candle_1',
+      'light.hue_candle_2',
+    ]);
+  });
+
+  it('patches snapshots from realtime Home Assistant state events', () => {
+    const snapshot = {
+      loadedAt: new Date().toISOString(),
+      states,
+      areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+      devices: [],
+      registryEntities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+      entities: buildHomeAssistantEntities(states, {
+        areas: [{ area_id: 'kitchen', name: 'Kitchen' }],
+        devices: [],
+        entities: [{ entity_id: 'light.kitchen', area_id: 'kitchen' }],
+      }),
+    };
+
+    const patched = patchHomeAssistantSnapshotState(snapshot, {
+      entity_id: 'light.kitchen',
+      state: 'off',
+      attributes: { friendly_name: 'Kitchen Light' },
+    });
+
+    expect(patched.states.find((state) => state.entity_id === 'light.kitchen')?.state).toBe('off');
+    expect(patched.entities.find((entity) => entity.entityId === 'light.kitchen')).toMatchObject({
+      areaId: 'kitchen',
+      areaName: 'Kitchen',
+      state: 'off',
+    });
+  });
+
+  it('uses explicit service calls for deterministic toggles', () => {
+    const entities = buildHomeAssistantEntities(states, {
+      areas: [],
+      devices: [],
+      entities: [],
+    });
+
+    expect(getToggleAction(entities.find((entity) => entity.entityId === 'light.kitchen')!)).toMatchObject({
+      domain: 'light',
+      service: 'turn_off',
+      nextState: 'off',
+    });
+    expect(getToggleAction(entities.find((entity) => entity.entityId === 'light.living_room')!)).toMatchObject({
+      domain: 'light',
+      service: 'turn_on',
+      nextState: 'on',
+    });
   });
 
   it('counts active binary sensors as security activity', () => {


### PR DESCRIPTION
## Summary
- add realtime Home Assistant WebSocket state updates with polling fallback
- make Home light/room controls deterministic with shared optimistic state and stable natural ordering
- keep Home widget config loading resilient when one encrypted field cannot be decrypted
- update the README widget gallery so every registered widget is named, including Home widgets

## Validation
- bun run build:types
- bunx vitest run tests/unit/homeAssistantUtils.test.ts
- bun run test
- bun run lint
- bun run test:e2e
- Browser QA on https://boxento.app.orb.local/ with live Home Assistant light updates
- README widget catalog check for all 36 registered widgets

## Release note
Home widgets now support realtime Home Assistant state updates, deterministic toggles, stable light ordering, shared snapshots, and polling fallback.