### PR TITLE
Simplify widget layouts

### DIFF
--- a/src/components/dashboard/DashboardContextMenu.tsx
+++ b/src/components/dashboard/DashboardContextMenu.tsx
@@ -11,7 +11,7 @@ import {
 import { AppSettingsModal } from '@/components/settings/AppSettingsModal';
 import {
   Plus,
-  Settings,
+  Settings2,
   LayoutGrid
 } from 'lucide-react';
 
@@ -88,7 +88,7 @@ export function DashboardContextMenu({ children, onAddWidget, onAutoArrange }: D
             >
               <div className="flex items-center">
                 <div className="bg-primary/10 rounded-full p-1.5 mr-3 group-hover:bg-primary/20 group-focus:bg-primary/20 transition-colors">
-                  <Settings className="h-4 w-4 text-primary" />
+                  <Settings2 className="h-4 w-4 text-primary" />
                 </div>
                 <span>App Settings</span>
               </div>

--- a/src/components/dashboard/DashboardSwitcher.tsx
+++ b/src/components/dashboard/DashboardSwitcher.tsx
@@ -24,7 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { ChevronDown, Plus, Settings, Lock, Globe, Users, Copy, Check, Trash2 } from 'lucide-react';
+import { ChevronDown, Plus, Settings2, Lock, Globe, Users, Copy, Check, Trash2 } from 'lucide-react';
 
 export type DashboardVisibility = 'private' | 'team' | 'public';
 export type ShareRole = 'viewer' | 'editor';
@@ -170,7 +170,7 @@ export function DashboardSwitcher({
             onClick={handleOpenSettings}
             className="cursor-pointer"
           >
-            <Settings className="h-4 w-4 mr-2" />
+            <Settings2 className="h-4 w-4 mr-2" />
             Dashboard Settings
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/components/widgets/CronHealthWidget/index.tsx
+++ b/src/components/widgets/CronHealthWidget/index.tsx
@@ -25,7 +25,7 @@ import {
   ChevronLeft,
   Activity,
   Clock,
-  Settings
+  Settings2
 } from 'lucide-react';
 
 type CronHealthWidgetProps = WidgetProps<CronHealthWidgetConfig>;
@@ -700,7 +700,7 @@ const CronHealthWidget: React.FC<CronHealthWidgetProps> = ({ width, height, conf
       <div className="w-full h-full flex flex-col bg-card rounded-lg p-2 md:p-3">
         <WidgetHeader title={localConfig.title} onSettingsClick={readOnly ? undefined : () => setShowSettings(true)} />
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Settings className="h-8 w-8" />
+          <Settings2 className="h-8 w-8" />
           <p className="text-sm">Configure the health API URL</p>
           {!readOnly && (
             <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/FavaWidget/index.tsx
+++ b/src/components/widgets/FavaWidget/index.tsx
@@ -25,7 +25,7 @@ import {
   ChevronRight,
   ChevronDown,
   Search,
-  Settings,
+  Settings2,
   RefreshCw,
   DollarSign,
   BarChart3,
@@ -266,7 +266,7 @@ const FavaWidget: React.FC<FavaWidgetProps> = ({ width, height, config }) => {
       <div className="widget-container h-full flex flex-col p-2 md:p-3">
         <WidgetHeader title={localConfig.title} onSettingsClick={readOnly ? undefined : () => setShowSettings(true)} />
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Settings className="h-8 w-8" />
+          <Settings2 className="h-8 w-8" />
           <p className="text-sm">Configure Fava URL to get started</p>
           {!readOnly && (
             <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/HealthchecksWidget/index.tsx
+++ b/src/components/widgets/HealthchecksWidget/index.tsx
@@ -6,7 +6,7 @@ import {
   ExternalLink,
   RefreshCw,
   Search,
-  Settings,
+  Settings2,
   Siren,
   Timer,
   XCircle,
@@ -285,7 +285,7 @@ const HealthchecksWidget: React.FC<Props> = ({ width, height, config }) => {
 
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-muted-foreground">
-        <Settings className="h-8 w-8" />
+        <Settings2 className="h-8 w-8" />
         <p className="text-sm">Add your Healthchecks URL and read-only API key to get started.</p>
         {!readOnly && (
           <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/JellyfinWidget/index.tsx
+++ b/src/components/widgets/JellyfinWidget/index.tsx
@@ -26,7 +26,7 @@ import {
   Music,
   Loader2,
   AlertCircle,
-  Settings,
+  Settings2,
   ExternalLink,
   Library,
   Search,
@@ -302,7 +302,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
 
   const renderNeedsConfig = () => {
     if (isTiny) {
-      const setupIcon = <Settings className="h-5 w-5 text-muted-foreground" />;
+      const setupIcon = <Settings2 className="h-5 w-5 text-muted-foreground" />;
 
       if (readOnly) {
         return (
@@ -326,7 +326,7 @@ const JellyfinWidget: React.FC<JellyfinWidgetProps> = ({ width, height, config }
 
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-        <Settings className="h-8 w-8" />
+        <Settings2 className="h-8 w-8" />
         <p className="text-sm">Configure Jellyfin to get started</p>
         {!readOnly && (
           <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/KumaWidget/index.tsx
+++ b/src/components/widgets/KumaWidget/index.tsx
@@ -5,7 +5,7 @@ import {
   ExternalLink,
   RefreshCw,
   Search,
-  Settings,
+  Settings2,
   XCircle,
 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
@@ -271,7 +271,7 @@ const KumaWidget: React.FC<Props> = ({ width, height, config }) => {
 
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-muted-foreground">
-        <Settings className="h-8 w-8" />
+        <Settings2 className="h-8 w-8" />
         <p className="text-sm">Add your Uptime Kuma status page URL to get started.</p>
         {!readOnly && (
           <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/NotesWidget/index.tsx
+++ b/src/components/widgets/NotesWidget/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { StickyNote, FileText, Type, Hash, AlignLeft, Settings } from 'lucide-react';
+import { StickyNote, FileText, Type, Hash, AlignLeft, Settings2 } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -318,7 +318,7 @@ const NotesWidget: React.FC<NotesWidgetProps> = ({ width = 2, height = 2, config
                 onClick={() => setShowSettings(true)}
                 aria-label="Notes settings"
               >
-                <Settings size={14} />
+                <Settings2 size={14} />
               </Button>
             )}
           </div>

--- a/src/components/widgets/OllamaWidget/index.tsx
+++ b/src/components/widgets/OllamaWidget/index.tsx
@@ -21,7 +21,7 @@ import {
 import WidgetHeader from '../common/WidgetHeader';
 import { OllamaWidgetConfig, OllamaWidgetProps, ChatMessage, OllamaModel } from './types';
 import { cn } from '@/lib/utils';
-import { Bot, Send, Loader2, AlertCircle, Trash2, Settings, MessageSquare, Cpu } from 'lucide-react';
+import { Bot, Send, Loader2, AlertCircle, Trash2, Settings2, MessageSquare, Cpu } from 'lucide-react';
 
 const defaultConfig: OllamaWidgetConfig = {
   title: 'Ollama',
@@ -732,7 +732,7 @@ const OllamaWidget: React.FC<OllamaWidgetProps> = ({ width, height, config }) =>
           onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
         />
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Settings className="h-8 w-8" />
+          <Settings2 className="h-8 w-8" />
           <p className="text-sm">Configure Ollama to get started</p>
           {!readOnly && (
             <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/PaisaWidget/index.tsx
+++ b/src/components/widgets/PaisaWidget/index.tsx
@@ -26,7 +26,7 @@ import {
   Home,
   Car,
   CreditCard,
-  Settings,
+  Settings2,
   RefreshCw,
   ArrowUpRight,
   ArrowDownRight,
@@ -265,7 +265,7 @@ const PaisaWidget: React.FC<PaisaWidgetProps> = ({ width, height, config }) => {
           onSettingsClick={readOnly ? undefined : () => handleSettingsOpen(true)}
         />
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Settings className="h-8 w-8" />
+          <Settings2 className="h-8 w-8" />
           <p className="text-sm">Configure Paisa URL to get started</p>
           {!readOnly && (
             <Button variant="outline" size="sm" onClick={() => handleSettingsOpen(true)}>

--- a/src/components/widgets/QRCodeWidget/index.tsx
+++ b/src/components/widgets/QRCodeWidget/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { QrCode, Download, Copy, Check, Plus, Trash2, Settings, Clock } from 'lucide-react';
+import { QrCode, Download, Copy, Check, Plus, Trash2, Settings2, Clock } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -211,7 +211,7 @@ const QRCodeWidget: React.FC<QRCodeWidgetProps> = ({ width, height, config }) =>
         compactLayout ? 'gap-1.5 px-2 text-center' : 'gap-2'
       )}
     >
-      <Settings className={cn(compactLayout ? 'h-5 w-5' : 'h-8 w-8')} />
+      <Settings2 className={cn(compactLayout ? 'h-5 w-5' : 'h-8 w-8')} />
       <p
         className={cn(
           'text-center',

--- a/src/components/widgets/ReadwiseWidget/index.tsx
+++ b/src/components/widgets/ReadwiseWidget/index.tsx
@@ -13,7 +13,7 @@ import {
   Quote,
   AlertCircle,
   BookOpen,
-  Settings,
+  Settings2,
   Search,
   ChevronRight,
   Tag,
@@ -312,7 +312,7 @@ const ReadwiseWidget: React.FC<ReadwiseWidgetProps> = ({ width, height, config }
           compact={isTiny}
         />
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Settings className="h-8 w-8" />
+          <Settings2 className="h-8 w-8" />
           <p className="text-sm">Configure this widget to get started</p>
           {!readOnly && (
             <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/RivenWidget/index.tsx
+++ b/src/components/widgets/RivenWidget/index.tsx
@@ -21,7 +21,7 @@ import {
   Check,
   Star,
   Tv,
-  Settings,
+  Settings2,
   Clock,
   TrendingUp,
   Library,
@@ -298,7 +298,7 @@ const RivenWidget: React.FC<RivenWidgetProps> = ({ width, height, config }) => {
           onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
         />
         <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Settings className="h-8 w-8" />
+          <Settings2 className="h-8 w-8" />
           <p className="text-sm">Configure Riven to get started</p>
           {!readOnly && (
             <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/ServicesWidget/index.tsx
+++ b/src/components/widgets/ServicesWidget/index.tsx
@@ -819,11 +819,15 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
   const handleAddService = useCallback(() => {
     if (!newService.name || !newService.url) return;
 
+    const description = newService.description?.trim();
+    const icon = newService.icon?.trim();
+
     const service: Service = {
       id: `service-${Date.now()}`,
       name: newService.name.trim(),
       url: newService.url.trim(),
-      icon: 'Globe',
+      icon: icon || 'Globe',
+      description: description || undefined,
       category: newService.category?.trim() || undefined
     };
 
@@ -845,7 +849,10 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
   const renderServiceSettingsRow = useCallback((service: Service) => {
     const Icon = getIcon(service.icon);
     const serviceHost = getServiceHost(service.url);
-    const meta = service.category || service.description || serviceHost;
+    const meta = [service.category, service.description]
+      .map(item => item?.trim())
+      .filter((item): item is string => Boolean(item))
+      .join(' · ') || serviceHost;
 
     return (
       <div
@@ -1046,6 +1053,39 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           }
         />
       </div>
+
+      <details className="rounded-md border border-border/70 px-3 py-2">
+        <summary className="cursor-pointer text-sm font-medium text-foreground">
+          Optional details
+        </summary>
+        <div className="mt-3 space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="service-desc">Description</Label>
+            <Input
+              id="service-desc"
+              type="text"
+              placeholder="Dashboard"
+              value={newService.description || ''}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setNewService(prev => ({ ...prev, description: e.target.value }))
+              }
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="service-icon">Icon</Label>
+            <Input
+              id="service-icon"
+              type="text"
+              placeholder="Globe, LayoutGrid, Play, Bot"
+              value={newService.icon || ''}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setNewService(prev => ({ ...prev, icon: e.target.value }))
+              }
+            />
+          </div>
+        </div>
+      </details>
     </WidgetSettingsDialog>
   );
 

--- a/src/components/widgets/ServicesWidget/index.tsx
+++ b/src/components/widgets/ServicesWidget/index.tsx
@@ -1,17 +1,11 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter
-} from '../../ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '../../ui/button';
 import { Label } from '../../ui/label';
 import { Switch } from '../../ui/switch';
 import WidgetHeader from '../common/WidgetHeader';
+import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../common/WidgetSettingsDialog';
 import { WidgetProps } from '@/types';
 import { ServicesWidgetConfig, Service } from './types';
 import { cn } from '@/lib/utils';
@@ -33,8 +27,6 @@ import {
   Activity,
   Search,
   Clock,
-  ChevronRight,
-  FolderOpen,
 } from 'lucide-react';
 
 type ServicesWidgetProps = WidgetProps<ServicesWidgetConfig>;
@@ -173,15 +165,6 @@ const getServiceHost = (url: string) => {
   }
 };
 
-const getServicePort = (url: string) => {
-  try {
-    const parsed = new URL(url);
-    return parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
-  } catch {
-    return '';
-  }
-};
-
 const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }) => {
   // --- Size detection (icon -> widget -> app spectrum) ---
   const isTiny = width === 1 && height === 1;
@@ -191,6 +174,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
   const isTall = height >= 4;
   const isApp = width >= 8 && height >= 6;
   const isDirectory = width >= 6 && height >= 6;
+  const showDirectoryFilters = isDirectory || isApp;
   const readOnly = config?.readOnly ?? false;
 
   const mergedConfig = useMemo(() => mergeConfigWithDefaults(config), [config]);
@@ -203,9 +187,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
   const [showAddService, setShowAddService] = useState<boolean>(false);
   const [newService, setNewService] = useState<Partial<Service>>({});
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [containerWidth, setContainerWidth] = useState(0);
 
-  // App-mode state
   const [selectedServiceId, setSelectedServiceId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -261,55 +243,35 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     return () => clearInterval(interval);
   }, [localConfig.services, localConfig.showStatus, localConfig.checkInterval, checkServiceStatus]);
 
-  // Measure container width
-  useEffect(() => {
-    const element = containerRef.current;
-    if (!element) return;
-
-    const updateWidth = () => {
-      setContainerWidth(element.getBoundingClientRect().width);
-    };
-
-    updateWidth();
-
-    const observer = new ResizeObserver(updateWidth);
-    observer.observe(element);
-
-    return () => observer.disconnect();
-  }, []);
-
   // Open service in new tab
   const openService = useCallback((url: string) => {
     window.open(url, '_blank', 'noopener,noreferrer');
   }, []);
 
   // Computed stats
-  const { categories, onlineCount, offlineCount, checkingCount } = useMemo(() => {
+  const { categories, onlineCount, offlineCount } = useMemo(() => {
     const cats = new Set<string>();
     let online = 0;
     let offline = 0;
-    let checking = 0;
 
     localConfig.services.forEach(service => {
       if (service.category) cats.add(service.category);
       const status = serviceStatus[service.id];
       if (status === 'online') online += 1;
       else if (status === 'offline') offline += 1;
-      else if (status === 'checking') checking += 1;
     });
 
     return {
       categories: Array.from(cats).sort(),
       onlineCount: online,
       offlineCount: offline,
-      checkingCount: checking,
     };
   }, [localConfig.services, serviceStatus]);
 
   // Filtered services (for app/panel mode)
   const filteredServices = useMemo(() => {
     let services = localConfig.services;
-    if (selectedCategory) {
+    if (showDirectoryFilters && selectedCategory) {
       services = services.filter(s => s.category === selectedCategory);
     }
     if (searchQuery.trim()) {
@@ -322,7 +284,7 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
       );
     }
     return services;
-  }, [localConfig.services, selectedCategory, searchQuery]);
+  }, [localConfig.services, selectedCategory, searchQuery, showDirectoryFilters]);
 
   const selectedService = useMemo(() => {
     if (!selectedServiceId) return null;
@@ -344,21 +306,9 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     );
   }, [filteredServices, isApp]);
 
-  const serviceCountLabel = searchQuery || selectedCategory
+  const serviceCountLabel = searchQuery || (showDirectoryFilters && selectedCategory)
     ? `${filteredServices.length} of ${localConfig.services.length} services`
     : `${localConfig.services.length} services`;
-
-  const getGridColumns = (measuredWidth: number) => {
-    if (measuredWidth >= 1500) return 5;
-    if (measuredWidth >= 1100) return 4;
-    if (measuredWidth >= 680) return 3;
-    if (measuredWidth >= 430) return 2;
-    if (width >= 12) return 5;
-    if (width >= 9) return 4;
-    if (width >= 6) return 3;
-    if (width >= 3) return 2;
-    return 1;
-  };
 
   const getCompactGridCols = () => {
     if (width >= 4) return 'grid-cols-4';
@@ -447,59 +397,37 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     );
   };
 
-  // Full service card (for default / panel grid)
-  const renderFullServiceCard = (service: Service) => {
+  const renderSimpleServiceRow = (service: Service) => {
     const Icon = getIcon(service.icon);
     const status = serviceStatus[service.id];
     const serviceHost = getServiceHost(service.url);
-    const StatusIcon = getStatusIcon(status);
 
     return (
       <Button type="button" variant="ghost" size="none"
         key={service.id}
         onClick={() => openService(service.url)}
-        className="group flex h-full min-h-[112px] flex-col justify-between rounded-xl border border-border bg-muted/30 p-4 text-left transition-colors hover:bg-accent"
+        className="group flex w-full justify-start rounded-lg px-2.5 py-2 text-left transition-colors hover:bg-accent"
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex min-w-0 items-start gap-3">
-            <div className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-card text-foreground shadow-sm ring-1 ring-border">
-              <Icon className="h-5 w-5" />
-            </div>
-            <div className="min-w-0">
-              <div className="truncate text-sm font-semibold text-foreground">{service.name}</div>
-              <div className="mt-0.5 truncate text-xs text-muted-foreground">{serviceHost}</div>
-            </div>
+        <div className="flex w-full min-w-0 items-center gap-2.5">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-foreground">
+            <Icon className="size-4" />
           </div>
-          {localConfig.showStatus && (
-            <div className="flex items-center gap-1.5 rounded-full bg-card px-2 py-1 text-[11px] font-medium text-muted-foreground ring-1 ring-border">
-              <div className={cn('h-2 w-2 rounded-full', getStatusColor(status))} />
-              <StatusIcon className="h-3.5 w-3.5" />
-              <span>{getStatusLabel(status)}</span>
-            </div>
-          )}
-        </div>
 
-        <div className="min-w-0 flex-1 mt-2">
-          <div className="line-clamp-2 text-sm text-muted-foreground">
-            {service.description || 'Open service dashboard'}
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="truncate text-sm font-semibold text-foreground">
+                {service.name}
+              </span>
+              {localConfig.showStatus ? (
+                <span className={cn('size-2 shrink-0 rounded-full', getStatusColor(status))} />
+              ) : null}
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              {serviceHost}
+            </div>
           </div>
-        </div>
 
-        <div className="flex items-center justify-between gap-3 text-[11px] text-muted-foreground mt-2">
-          <div className="flex min-w-0 items-center gap-2">
-            {service.category && (
-              <span className="truncate rounded-full bg-card px-2 py-1 ring-1 ring-border">
-                {service.category}
-              </span>
-            )}
-            {responseTime[service.id] !== undefined && localConfig.showStatus && (
-              <span className="flex items-center gap-1">
-                <Clock className="h-3 w-3" />
-                {responseTime[service.id]}ms
-              </span>
-            )}
-          </div>
-          <ArrowUpRight className="h-3.5 w-3.5 flex-shrink-0 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+          <ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
         </div>
       </Button>
     );
@@ -512,44 +440,32 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     </div>
   );
 
-  // Default (3x3): summary bar + service card grid
+  // Default (3x3): calm launcher list
   const renderDefault = () => {
     const services = localConfig.services;
-    const regularColumns = Math.min(getGridColumns(containerWidth), Math.max(services.length, 1));
 
     return (
-      <div className="flex h-full flex-col gap-3 overflow-hidden">
-        <div className="flex flex-wrap items-center gap-2 px-1 text-[11px] text-muted-foreground">
-          <Badge variant="secondary" className="bg-muted px-2.5 py-1 text-foreground">
-            {services.length} services
-          </Badge>
-          {localConfig.showStatus && (
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <div className="flex shrink-0 items-center gap-2 px-1 pb-2 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{services.length} services</span>
+          {localConfig.showStatus ? (
             <>
-              <Badge variant="secondary" className="bg-green-500/10 px-2.5 py-1 text-green-700 dark:text-green-300">
+              <span className="flex items-center gap-1">
+                <span className="size-1.5 rounded-full bg-green-500" />
                 {onlineCount} online
-              </Badge>
-              {offlineCount > 0 && (
-                <Badge variant="secondary" className="bg-red-500/10 px-2.5 py-1 text-red-700 dark:text-red-300">
+              </span>
+              {offlineCount > 0 ? (
+                <span className="flex items-center gap-1">
+                  <span className="size-1.5 rounded-full bg-red-500" />
                   {offlineCount} offline
-                </Badge>
-              )}
-              {checkingCount > 0 && (
-                <Badge variant="secondary" className="bg-yellow-500/10 px-2.5 py-1 text-yellow-700 dark:text-yellow-300">
-                  {checkingCount} checking
-                </Badge>
-              )}
+                </span>
+              ) : null}
             </>
-          )}
+          ) : null}
         </div>
 
-        <div
-          className="grid flex-1 gap-3 overflow-auto pr-1"
-          style={{
-            gridTemplateColumns: `repeat(${regularColumns}, minmax(0, 1fr))`,
-            gridAutoRows: 'minmax(112px, auto)',
-          }}
-        >
-          {services.map(service => renderFullServiceCard(service))}
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {services.map(service => renderSimpleServiceRow(service))}
         </div>
       </div>
     );
@@ -559,12 +475,12 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     const Icon = getIcon(service.icon);
     const status = serviceStatus[service.id];
     const StatusIcon = getStatusIcon(status);
-    const rt = responseTime[service.id];
 
     return (
       <Button type="button" variant="ghost" size="none"
         key={service.id}
         onClick={() => openService(service.url)}
+        aria-label={`Open ${service.name}`}
         className="flex w-full justify-start rounded-none border-b border-border/60 px-3 py-3 text-left transition-colors hover:bg-accent last:border-b-0"
       >
         <div className="flex w-full min-w-0 items-center gap-3">
@@ -575,9 +491,6 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
               <span className="truncate text-sm font-medium text-foreground">{service.name}</span>
-              {localConfig.showStatus && (
-                <span className={cn('h-2 w-2 shrink-0 rounded-full', getStatusColor(status))} />
-              )}
             </div>
             <div className="mt-0.5 truncate text-xs text-muted-foreground">
               {service.description || getServiceHost(service.url)}
@@ -598,12 +511,6 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
                 {getStatusLabel(status)}
               </span>
             )}
-            {rt !== undefined && localConfig.showStatus && (
-              <span className="hidden items-center gap-1 sm:inline-flex">
-                <Clock className="h-3.5 w-3.5" />
-                {rt}ms
-              </span>
-            )}
             <ArrowUpRight className="h-3.5 w-3.5" />
           </div>
         </div>
@@ -613,26 +520,19 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
 
   const renderDirectory = () => (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
-      <div className="space-y-3 px-3 py-2">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+      <div className={cn('px-3 py-2', showDirectoryFilters ? 'space-y-3' : 'space-y-2')}>
+        <div className={cn(
+          showDirectoryFilters
+            ? 'flex flex-wrap items-center justify-between gap-3'
+            : 'flex items-center gap-2'
+        )}>
+          <div className="flex shrink-0 flex-wrap items-center gap-3 text-xs text-muted-foreground">
             <span className="font-medium text-foreground">{serviceCountLabel}</span>
-            {localConfig.showStatus && (
-              <>
-                <span className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-green-500" />
-                  {onlineCount} up
-                </span>
-                {offlineCount > 0 && (
-                  <span className="flex items-center gap-1">
-                    <div className="h-2 w-2 rounded-full bg-red-500" />
-                    {offlineCount} down
-                  </span>
-                )}
-              </>
-            )}
           </div>
-          <div className="relative min-w-[12rem] flex-1 sm:max-w-[18rem]">
+          <div className={cn(
+            'relative min-w-0 flex-1',
+            showDirectoryFilters && 'min-w-[12rem] sm:max-w-[18rem]'
+          )}>
             <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               placeholder="Filter..."
@@ -643,32 +543,34 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           </div>
         </div>
 
-        <div className="flex flex-wrap gap-1.5">
-          <Button type="button" variant="ghost" size="none"
-            onClick={() => setSelectedCategory(null)}
-            className={cn(
-              'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
-              !selectedCategory && 'bg-accent text-foreground'
-            )}
-          >
-            All ({localConfig.services.length})
-          </Button>
-          {categories.map(cat => {
-            const count = localConfig.services.filter(s => s.category === cat).length;
-            return (
-              <Button type="button" variant="ghost" size="none"
-                key={cat}
-                onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
-                className={cn(
-                  'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
-                  selectedCategory === cat && 'bg-accent text-foreground'
-                )}
-              >
-                {cat} ({count})
-              </Button>
-            );
-          })}
-        </div>
+        {showDirectoryFilters && (
+          <div className="flex flex-wrap gap-1.5">
+            <Button type="button" variant="ghost" size="none"
+              onClick={() => setSelectedCategory(null)}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
+                !selectedCategory && 'bg-accent text-foreground'
+              )}
+            >
+              All ({localConfig.services.length})
+            </Button>
+            {categories.map(cat => {
+              const count = localConfig.services.filter(s => s.category === cat).length;
+              return (
+                <Button type="button" variant="ghost" size="none"
+                  key={cat}
+                  onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
+                  className={cn(
+                    'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
+                    selectedCategory === cat && 'bg-accent text-foreground'
+                  )}
+                >
+                  {cat} ({count})
+                </Button>
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto border-t border-border/60">
@@ -683,243 +585,47 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     </div>
   );
 
-  // Panel (4x4-5x5): category sidebar + service grid
-  const renderPanel = () => {
-    const panelColumns = Math.min(getGridColumns(containerWidth * 0.65), Math.max(filteredServices.length, 1));
+  // Panel and app sizes keep the same simple job: find a service, see status, open it.
+  const renderPanel = () => renderDirectory();
+
+  const renderAppServiceRow = (service: Service) => {
+    const Icon = getIcon(service.icon);
+    const status = serviceStatus[service.id];
+    const isSelected = selectedServiceId === service.id;
 
     return (
-      <div className="flex flex-col h-full overflow-hidden">
-        {/* Summary bar */}
-        <div className="flex items-center justify-between px-3 py-2">
-          <div className="flex items-center gap-3 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">{localConfig.services.length} services</span>
-            {localConfig.showStatus && (
-              <>
-                <span className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-green-500" />
-                  {onlineCount} up
-                </span>
-                {offlineCount > 0 && (
-                  <span className="flex items-center gap-1">
-                    <div className="h-2 w-2 rounded-full bg-red-500" />
-                    {offlineCount} down
-                  </span>
-                )}
-              </>
-            )}
+      <Button
+        type="button"
+        variant="ghost"
+        size="none"
+        key={service.id}
+        onClick={() => setSelectedServiceId(service.id)}
+        aria-label={`Select ${service.name}`}
+        className={cn(
+          'flex w-full justify-start rounded-none border-b border-border/60 px-3 py-3 text-left transition-colors hover:bg-accent last:border-b-0',
+          isSelected && 'bg-accent'
+        )}
+      >
+        <div className="flex w-full min-w-0 items-center gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-card ring-1 ring-border">
+            <Icon className="h-4 w-4 text-foreground" />
           </div>
-          <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              placeholder="Filter..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="h-7 w-40 pl-7 text-xs"
-            />
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-sm font-medium text-foreground">{service.name}</span>
+              {localConfig.showStatus ? (
+                <span className={cn('size-2 shrink-0 rounded-full', getStatusColor(status))} />
+              ) : null}
+            </div>
+            <div className="mt-0.5 truncate text-xs text-muted-foreground">
+              {service.description || getServiceHost(service.url)}
+            </div>
           </div>
         </div>
-        {/* Two-column content */}
-        <div className="flex flex-1 overflow-hidden">
-          {/* Category sidebar */}
-          <div className="w-36 shrink-0 border-r border-border overflow-y-auto">
-            <Button type="button" variant="ghost" size="none"
-              onClick={() => setSelectedCategory(null)}
-              className={cn(
-                'w-full px-3 py-2 text-left text-xs transition-colors hover:bg-accent',
-                !selectedCategory && 'bg-accent font-medium text-foreground'
-              )}
-            >
-              All ({localConfig.services.length})
-            </Button>
-            {categories.map(cat => {
-              const count = localConfig.services.filter(s => s.category === cat).length;
-              return (
-                <Button type="button" variant="ghost" size="none"
-                  key={cat}
-                  onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
-                  className={cn(
-                    'w-full px-3 py-2 text-left text-xs transition-colors hover:bg-accent',
-                    selectedCategory === cat && 'bg-accent font-medium text-foreground'
-                  )}
-                >
-                  {cat} ({count})
-                </Button>
-              );
-            })}
-          </div>
-          {/* Service grid */}
-          <div className="flex-1 overflow-y-auto p-3">
-            {filteredServices.length === 0 ? (
-              <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                No services match filter
-              </div>
-            ) : (
-              <div
-                className="grid gap-3"
-                style={{
-                  gridTemplateColumns: `repeat(${panelColumns}, minmax(0, 1fr))`,
-                  gridAutoRows: 'minmax(112px, auto)',
-                }}
-              >
-                {filteredServices.map(service => renderFullServiceCard(service))}
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      </Button>
     );
   };
 
-  // App (8x6+): full service dashboard - master-detail with categories, search, response times
-  const renderApp = () => {
-    return (
-      <div className="flex h-full min-h-0 overflow-hidden">
-        {/* Left sidebar: categories + service list */}
-        <div className="flex w-[38%] min-w-[260px] max-w-[420px] flex-col border-r border-border">
-          {/* Search */}
-          <div className="p-2 widget-drag-handle cursor-move">
-            <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Search services..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9 h-8 text-sm"
-              />
-            </div>
-          </div>
-
-          {/* Category filter tabs */}
-          <div className="flex flex-wrap items-center gap-1 px-2 py-1.5 border-b border-border">
-            <Button type="button" variant="ghost" size="none"
-              onClick={() => setSelectedCategory(null)}
-              className={cn(
-                'shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors',
-                !selectedCategory
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:bg-accent'
-              )}
-            >
-              All
-            </Button>
-            {categories.map(cat => (
-              <Button type="button" variant="ghost" size="none"
-                key={cat}
-                onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
-                className={cn(
-                  'shrink-0 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors',
-                  selectedCategory === cat
-                    ? 'bg-primary text-primary-foreground'
-                    : 'text-muted-foreground hover:bg-accent'
-                )}
-              >
-                {cat}
-              </Button>
-            ))}
-          </div>
-
-          {/* Service list */}
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            {filteredServices.length === 0 ? (
-              <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
-                <Search className="h-6 w-6" />
-                <span className="text-sm">No services found</span>
-              </div>
-            ) : (
-              filteredServices.map(service => {
-                const Icon = getIcon(service.icon);
-                const status = serviceStatus[service.id];
-                const isSelected = selectedServiceId === service.id;
-                return (
-                  <div
-                    key={service.id}
-                    className={cn(
-                      'flex items-center gap-3 px-3 py-2.5 cursor-pointer border-b border-border/50 transition-colors hover:bg-accent',
-                      isSelected && 'bg-accent'
-                    )}
-                    onClick={() => setSelectedServiceId(service.id)}
-                  >
-                    <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-card ring-1 ring-border">
-                      <Icon className="h-4 w-4 text-foreground" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-2">
-                        <span className="truncate text-sm font-medium text-foreground">{service.name}</span>
-                        {localConfig.showStatus && (
-                          <div className={cn('h-2 w-2 shrink-0 rounded-full', getStatusColor(status))} />
-                        )}
-                      </div>
-                      <div className="truncate text-xs text-muted-foreground mt-0.5">
-                        {service.description || getServiceHost(service.url)}
-                      </div>
-                    </div>
-                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  </div>
-                );
-              })
-            )}
-          </div>
-
-          {/* Bottom status bar */}
-          <div className="flex items-center gap-3 border-t border-border px-3 py-2 text-[11px] text-muted-foreground">
-            <span>{localConfig.services.length} total</span>
-            {localConfig.showStatus && (
-              <>
-                <span className="flex items-center gap-1">
-                  <div className="h-1.5 w-1.5 rounded-full bg-green-500" />
-                  {onlineCount}
-                </span>
-                <span className="flex items-center gap-1">
-                  <div className="h-1.5 w-1.5 rounded-full bg-red-500" />
-                  {offlineCount}
-                </span>
-              </>
-            )}
-          </div>
-        </div>
-
-        {/* Right detail pane */}
-        <div className="min-w-0 flex-1 overflow-y-auto">
-          {selectedService ? (
-            <div className="p-5">
-              {renderServiceDetail(selectedService)}
-            </div>
-          ) : (
-            <div className="flex h-full flex-col items-center justify-center gap-3 text-muted-foreground">
-              <Server className="h-10 w-10" />
-              <div className="text-center">
-                <p className="text-sm font-medium">Select a service</p>
-                <p className="text-xs mt-1">Choose a service from the list to view details</p>
-              </div>
-              {/* Overview grid */}
-              <div className="mt-4 w-full max-w-lg px-6">
-                <div className="grid grid-cols-3 gap-3">
-                  <div className="rounded-lg border border-border bg-card p-3 text-center">
-                    <div className="text-2xl font-bold text-foreground">{localConfig.services.length}</div>
-                    <div className="text-xs text-muted-foreground mt-1">Total</div>
-                  </div>
-                  {localConfig.showStatus && (
-                    <>
-                      <div className="rounded-lg border border-border bg-card p-3 text-center">
-                        <div className="text-2xl font-bold text-green-600 dark:text-green-400">{onlineCount}</div>
-                        <div className="text-xs text-muted-foreground mt-1">Online</div>
-                      </div>
-                      <div className="rounded-lg border border-border bg-card p-3 text-center">
-                        <div className="text-2xl font-bold text-red-600 dark:text-red-400">{offlineCount}</div>
-                        <div className="text-xs text-muted-foreground mt-1">Offline</div>
-                      </div>
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  };
-
-  // Service detail view (used in app mode detail pane)
   const renderServiceDetail = (service: Service) => {
     const Icon = getIcon(service.icon);
     const status = serviceStatus[service.id];
@@ -927,51 +633,48 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     const rt = responseTime[service.id];
 
     return (
-      <div className="min-w-0 space-y-6">
-        {/* Header */}
+      <div className="space-y-5 p-5">
         <div className="flex min-w-0 items-start justify-between gap-4">
-          <div className="flex min-w-0 items-start gap-4">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-card text-foreground shadow-sm ring-1 ring-border">
-              <Icon className="h-7 w-7" />
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="flex size-12 shrink-0 items-center justify-center rounded-xl bg-card ring-1 ring-border">
+              <Icon className="size-6 text-foreground" />
             </div>
             <div className="min-w-0">
               <h2 className="truncate text-xl font-semibold text-foreground">{service.name}</h2>
-              <p className="mt-0.5 line-clamp-2 text-sm text-muted-foreground">
-                {service.description || 'No description'}
+              <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                {service.description || getServiceHost(service.url)}
               </p>
             </div>
           </div>
           <Button size="sm" onClick={() => openService(service.url)}>
-            <ArrowUpRight className="h-4 w-4 mr-1" />
+            <ArrowUpRight className="mr-1 size-4" />
             Open
           </Button>
         </div>
 
-        {/* Status + response time */}
-        {localConfig.showStatus && (
+        {localConfig.showStatus ? (
           <div className="grid grid-cols-2 gap-3">
             <div className="rounded-lg border border-border p-4">
-              <div className="text-xs text-muted-foreground mb-2">Status</div>
+              <div className="mb-2 text-xs text-muted-foreground">Status</div>
               <div className="flex items-center gap-2">
-                <div className={cn('h-3 w-3 rounded-full', getStatusColor(status))} />
-                <StatusIcon className="h-4 w-4 text-foreground" />
+                <span className={cn('size-3 rounded-full', getStatusColor(status))} />
+                <StatusIcon className="size-4 text-foreground" />
                 <span className="text-sm font-medium text-foreground">{getStatusLabel(status)}</span>
               </div>
             </div>
             <div className="rounded-lg border border-border p-4">
-              <div className="text-xs text-muted-foreground mb-2">Response Time</div>
+              <div className="mb-2 text-xs text-muted-foreground">Response Time</div>
               <div className="flex items-center gap-2">
-                <Clock className="h-4 w-4 text-foreground" />
+                <Clock className="size-4 text-foreground" />
                 <span className="text-sm font-medium text-foreground">
                   {rt !== undefined ? `${rt}ms` : '--'}
                 </span>
               </div>
             </div>
           </div>
-        )}
+        ) : null}
 
-        {/* Connection details */}
-        <div className="rounded-lg border border-border divide-y divide-border">
+        <div className="divide-y divide-border rounded-lg border border-border">
           <div className="flex items-start justify-between gap-4 px-4 py-3">
             <span className="shrink-0 text-sm text-muted-foreground">URL</span>
             <a
@@ -985,43 +688,87 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
           </div>
           <div className="flex items-start justify-between gap-4 px-4 py-3">
             <span className="shrink-0 text-sm text-muted-foreground">Host</span>
-            <span className="min-w-0 flex-1 break-all text-right text-sm text-foreground">{getServiceHost(service.url)}</span>
+            <span className="min-w-0 flex-1 break-all text-right text-sm text-foreground">
+              {getServiceHost(service.url)}
+            </span>
           </div>
-          <div className="flex items-start justify-between gap-4 px-4 py-3">
-            <span className="text-sm text-muted-foreground">Port</span>
-            <span className="text-sm font-mono text-foreground">{getServicePort(service.url)}</span>
-          </div>
-          {service.category && (
-            <div className="flex items-center justify-between px-4 py-3">
-              <span className="text-sm text-muted-foreground">Category</span>
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-foreground">
-                <FolderOpen className="h-3 w-3" />
-                {service.category}
-              </span>
+          {service.category ? (
+            <div className="flex items-center justify-between gap-4 px-4 py-3">
+              <span className="shrink-0 text-sm text-muted-foreground">Category</span>
+              <span className="min-w-0 truncate text-sm text-foreground">{service.category}</span>
             </div>
-          )}
-          {service.statusUrl && (
-            <div className="flex items-center justify-between px-4 py-3">
-              <span className="text-sm text-muted-foreground">Health URL</span>
-              <span className="text-sm font-mono text-foreground">{service.statusUrl}</span>
-            </div>
-          )}
-        </div>
-
-        {/* Actions */}
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => checkServiceStatus(service)}
-          >
-            <Activity className="h-4 w-4 mr-1" />
-            Check Now
-          </Button>
+          ) : null}
         </div>
       </div>
     );
   };
+
+  const renderApp = () => (
+    <div className="flex h-full min-h-0 overflow-hidden">
+      <div className="flex w-[38%] min-w-[260px] max-w-[420px] flex-col border-r border-border">
+        <div className="space-y-3 p-3">
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder="Filter..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-8 pl-7 text-xs"
+            />
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            <Button
+              type="button"
+              variant="ghost"
+              size="none"
+              onClick={() => setSelectedCategory(null)}
+              className={cn(
+                'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
+                !selectedCategory && 'bg-accent text-foreground'
+              )}
+            >
+              All
+            </Button>
+            {categories.map(cat => (
+              <Button
+                type="button"
+                variant="ghost"
+                size="none"
+                key={cat}
+                onClick={() => setSelectedCategory(cat === selectedCategory ? null : cat)}
+                className={cn(
+                  'rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors hover:bg-accent',
+                  selectedCategory === cat && 'bg-accent text-foreground'
+                )}
+              >
+                {cat}
+              </Button>
+            ))}
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto border-t border-border/60">
+          {filteredServices.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              No services match filter
+            </div>
+          ) : (
+            filteredServices.map(service => renderAppServiceRow(service))
+          )}
+        </div>
+      </div>
+
+      <div className="min-w-0 flex-1 overflow-y-auto">
+        {selectedService ? (
+          renderServiceDetail(selectedService)
+        ) : (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Select a service
+          </div>
+        )}
+      </div>
+    </div>
+  );
 
   // Empty state
   const renderEmptyState = () => (
@@ -1074,11 +821,10 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
 
     const service: Service = {
       id: `service-${Date.now()}`,
-      name: newService.name,
-      url: newService.url,
-      icon: newService.icon || 'Globe',
-      description: newService.description,
-      category: newService.category
+      name: newService.name.trim(),
+      url: newService.url.trim(),
+      icon: 'Globe',
+      category: newService.category?.trim() || undefined
     };
 
     setLocalConfig(prev => ({
@@ -1089,55 +835,42 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     setShowAddService(false);
   }, [newService]);
 
+  const handleAddServiceOpenChange = useCallback((nextOpen: boolean) => {
+    setShowAddService(nextOpen);
+    if (!nextOpen) {
+      setNewService({});
+    }
+  }, []);
+
   const renderServiceSettingsRow = useCallback((service: Service) => {
     const Icon = getIcon(service.icon);
-    const status = serviceStatus[service.id];
-    const StatusIcon = getStatusIcon(status);
+    const serviceHost = getServiceHost(service.url);
+    const meta = service.category || service.description || serviceHost;
 
     return (
       <div
         key={service.id}
-        className="grid min-w-[760px] grid-cols-[minmax(0,1.1fr)_minmax(0,1.7fr)_minmax(0,0.85fr)_auto] gap-3 px-3 py-2.5"
+        className="flex items-center gap-3 rounded-md border border-border/70 px-3 py-2.5"
       >
-        <div className="flex min-w-0 items-start gap-2">
-          <div className="mt-0.5 flex size-7 flex-shrink-0 items-center justify-center rounded-md bg-muted text-foreground">
-            <Icon className="size-3.5" />
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-foreground">
+          <Icon className="size-4" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-foreground">
+            {service.name}
           </div>
-          <div className="min-w-0">
-            <div className="truncate text-sm font-medium text-foreground">{service.name}</div>
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {serviceHost}
+          </div>
+          {meta !== serviceHost ? (
             <div className="mt-0.5 truncate text-xs text-muted-foreground">
-              {service.description || 'No description'}
+              {meta}
             </div>
-          </div>
+          ) : null}
         </div>
 
-        <div className="min-w-0">
-          <div className="truncate font-mono text-[11px] text-foreground" title={service.url}>
-            {service.url}
-          </div>
-          <div className="mt-1 truncate text-[11px] text-muted-foreground">
-            {getServiceHost(service.url)} : {getServicePort(service.url)}
-          </div>
-        </div>
-
-        <div className="min-w-0 text-[11px] text-muted-foreground">
-          <div className="truncate">{service.category || 'Uncategorized'}</div>
-          {localConfig.showStatus && (
-            <div
-              className={cn(
-                'mt-1 inline-flex items-center gap-1 font-medium',
-                status === 'online' && 'text-emerald-700 dark:text-emerald-300',
-                status === 'offline' && 'text-rose-700 dark:text-rose-300'
-              )}
-            >
-              <div className={cn('size-1.5 rounded-full', getStatusColor(status))} />
-              <StatusIcon className="size-3" />
-              <span>{getStatusLabel(status)}</span>
-            </div>
-          )}
-        </div>
-
-        <div className="flex items-start gap-1 justify-self-end">
+        <div className="flex shrink-0 items-center gap-1">
           <Button
             variant="ghost"
             size="icon"
@@ -1157,197 +890,163 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
         </div>
       </div>
     );
-  }, [handleDeleteService, localConfig.showStatus, openService, serviceStatus]);
+  }, [handleDeleteService, openService]);
 
   const renderSettings = () => (
-    <Dialog open={showSettings} onOpenChange={handleSettingsOpenChange}>
-      <DialogContent className="settings-dialog-content flex max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] flex-col overflow-hidden p-0 sm:max-w-[980px]">
-        <DialogHeader className="gap-2 px-6 pt-6">
-          <DialogTitle>{localConfig.title || 'Services'} Settings</DialogTitle>
-        </DialogHeader>
+    <WidgetSettingsDialog
+      open={showSettings}
+      onOpenChange={handleSettingsOpenChange}
+      title={`${localConfig.title || 'Services'} Settings`}
+      contentClassName="sm:max-w-lg"
+      bodyClassName="space-y-5"
+      footer={(
+        <WidgetSettingsDialogFooter
+          onDelete={config?.onDelete}
+          deleteLabel="Delete Widget"
+          onCancel={handleCancelSettings}
+          onSave={saveSettings}
+        />
+      )}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="title-input">Widget title</Label>
+        <Input
+          id="title-input"
+          type="text"
+          value={localConfig.title || ''}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setLocalConfig(prev => ({ ...prev, title: e.target.value }))
+          }
+        />
+      </div>
 
-        <div className="min-h-0 space-y-5 overflow-y-auto px-6 py-6">
-          <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
-            <div className="space-y-2">
-              <Label htmlFor="title-input">Widget title</Label>
-              <Input
-                id="title-input"
-                type="text"
-                value={localConfig.title || ''}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setLocalConfig(prev => ({ ...prev, title: e.target.value }))
-                }
-              />
-            </div>
-
-            <div className="flex items-center justify-between gap-4 rounded-md border border-border/70 px-3 py-2 md:min-w-[280px]">
-              <div className="min-w-0">
-                <Label htmlFor="status-toggle" className="text-sm font-medium">
-                  Show status indicators
-                </Label>
-                <p className="mt-0.5 text-xs text-muted-foreground">
-                  Surface online/offline state and response times.
-                </p>
-              </div>
-              <Switch
-                id="status-toggle"
-                checked={Boolean(localConfig.showStatus)}
-                onCheckedChange={(checked: boolean) =>
-                  setLocalConfig(prev => ({ ...prev, showStatus: checked }))
-                }
-              />
-            </div>
+      <div className="rounded-md border border-border/70 p-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <Label htmlFor="status-toggle" className="text-sm font-medium">
+              Status checks
+            </Label>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Show online/offline state in the widget.
+            </p>
           </div>
-
-          {localConfig.showStatus && (
-            <div className="space-y-2">
-              <Label htmlFor="interval-input">Check interval (seconds)</Label>
-              <Input
-                id="interval-input"
-                type="number"
-                min={10}
-                max={3600}
-                value={localConfig.checkInterval || 60}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setLocalConfig(prev => ({ ...prev, checkInterval: Number(e.target.value) || 60 }))
-                }
-                className="w-32"
-              />
-            </div>
-          )}
-
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-sm font-semibold text-foreground">Services</div>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {localConfig.services.length} total · {categories.length} categories
-                {localConfig.showStatus ? ` · ${onlineCount} online · ${offlineCount} offline` : ' · status hidden'}
-              </p>
-            </div>
-            <Button variant="outline" size="sm" onClick={() => setShowAddService(true)}>
-              <Plus className="h-4 w-4 mr-1" />
-              Add service
-            </Button>
-          </div>
-
-          <div className="overflow-hidden rounded-md border border-border/70">
-            <div className="overflow-x-auto">
-              <div className="grid min-w-[760px] grid-cols-[minmax(0,1.1fr)_minmax(0,1.7fr)_minmax(0,0.85fr)_auto] gap-3 border-b border-border/70 bg-muted/20 px-3 py-2 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                <span>Service</span>
-                <span>URL</span>
-                <span>Meta</span>
-                <span className="justify-self-end">Actions</span>
-              </div>
-
-              <div className="max-h-[min(54vh,520px)] divide-y divide-border/70 overflow-y-auto">
-                {localConfig.services.map((service) => renderServiceSettingsRow(service))}
-              </div>
-            </div>
-          </div>
+          <Switch
+            id="status-toggle"
+            checked={Boolean(localConfig.showStatus)}
+            onCheckedChange={(checked: boolean) =>
+              setLocalConfig(prev => ({ ...prev, showStatus: checked }))
+            }
+          />
         </div>
 
-        <DialogFooter className="px-6 py-4">
-          <div className="flex justify-between w-full">
-            {config?.onDelete && (
-              <Button variant="destructive" onClick={config.onDelete}>Delete Widget</Button>
-            )}
-            <div className="flex items-center gap-2 ml-auto">
-              <Button variant="outline" onClick={handleCancelSettings}>Cancel</Button>
-              <Button onClick={saveSettings}>Save</Button>
+        {localConfig.showStatus ? (
+          <div className="mt-3 flex items-center gap-2">
+            <Label htmlFor="interval-input" className="shrink-0 text-xs text-muted-foreground">
+              Check every
+            </Label>
+            <Input
+              id="interval-input"
+              type="number"
+              min={10}
+              max={3600}
+              value={localConfig.checkInterval || 60}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setLocalConfig(prev => ({ ...prev, checkInterval: Number(e.target.value) || 60 }))
+              }
+              className="h-8 w-20"
+            />
+            <span className="text-xs text-muted-foreground">seconds</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-foreground">Services</div>
+            <div className="text-xs text-muted-foreground">
+              {localConfig.services.length} saved
             </div>
           </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <Button variant="outline" size="sm" onClick={() => setShowAddService(true)}>
+            <Plus className="mr-1 size-4" />
+            Add service
+          </Button>
+        </div>
+
+        <div className="space-y-2">
+          {localConfig.services.length ? (
+            localConfig.services.map((service) => renderServiceSettingsRow(service))
+          ) : (
+            <div className="rounded-md border border-dashed border-border px-3 py-6 text-center text-sm text-muted-foreground">
+              No services yet
+            </div>
+          )}
+        </div>
+      </div>
+    </WidgetSettingsDialog>
   );
 
   const renderAddServiceDialog = () => (
-    <Dialog open={showAddService} onOpenChange={setShowAddService}>
-      <DialogContent className="settings-dialog-content sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>Add Service</DialogTitle>
-        </DialogHeader>
-
-        <div className="space-y-4">
-          <div>
-            <Label htmlFor="service-name">Name *</Label>
-            <Input
-              id="service-name"
-              type="text"
-              placeholder="My Service"
-              value={newService.name || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setNewService(prev => ({ ...prev, name: e.target.value }))
-              }
-            />
-          </div>
-
-          <div>
-            <Label htmlFor="service-url">URL *</Label>
-            <Input
-              id="service-url"
-              type="url"
-              placeholder="https://example.com"
-              value={newService.url || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setNewService(prev => ({ ...prev, url: e.target.value }))
-              }
-            />
-          </div>
-
-          <div>
-            <Label htmlFor="service-icon">Icon (Lucide icon name)</Label>
-            <Input
-              id="service-icon"
-              type="text"
-              placeholder="Globe, Server, Database..."
-              value={newService.icon || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setNewService(prev => ({ ...prev, icon: e.target.value }))
-              }
-            />
-          </div>
-
-          <div>
-            <Label htmlFor="service-desc">Description</Label>
-            <Input
-              id="service-desc"
-              type="text"
-              placeholder="What this service does"
-              value={newService.description || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setNewService(prev => ({ ...prev, description: e.target.value }))
-              }
-            />
-          </div>
-
-          <div>
-            <Label htmlFor="service-category">Category</Label>
-            <Input
-              id="service-category"
-              type="text"
-              placeholder="Finance, Media, AI..."
-              value={newService.category || ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setNewService(prev => ({ ...prev, category: e.target.value }))
-              }
-            />
-          </div>
+    <WidgetSettingsDialog
+      open={showAddService}
+      onOpenChange={handleAddServiceOpenChange}
+      title="Add Service"
+      contentClassName="sm:max-w-md"
+      bodyClassName="space-y-4"
+      footer={(
+        <div className="flex w-full justify-end gap-2">
+          <Button variant="outline" onClick={() => handleAddServiceOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleAddService}
+            disabled={!newService.name || !newService.url}
+          >
+            Add Service
+          </Button>
         </div>
+      )}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="service-name">Name</Label>
+        <Input
+          id="service-name"
+          type="text"
+          placeholder="Boxento"
+          value={newService.name || ''}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setNewService(prev => ({ ...prev, name: e.target.value }))
+          }
+        />
+      </div>
 
-        <DialogFooter>
-          <div className="flex justify-end w-full gap-2">
-            <Button variant="outline" onClick={() => setShowAddService(false)}>Cancel</Button>
-            <Button
-              onClick={handleAddService}
-              disabled={!newService.name || !newService.url}
-            >
-              Add Service
-            </Button>
-          </div>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <div className="space-y-2">
+        <Label htmlFor="service-url">URL</Label>
+        <Input
+          id="service-url"
+          type="url"
+          placeholder="https://boxento.local"
+          value={newService.url || ''}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setNewService(prev => ({ ...prev, url: e.target.value }))
+          }
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="service-category">Category</Label>
+        <Input
+          id="service-category"
+          type="text"
+          placeholder="Utilities"
+          value={newService.category || ''}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setNewService(prev => ({ ...prev, category: e.target.value }))
+          }
+        />
+      </div>
+    </WidgetSettingsDialog>
   );
 
   // --- Main render ---
@@ -1365,9 +1064,9 @@ const ServicesWidget: React.FC<ServicesWidgetProps> = ({ width, height, config }
     >
       {!isTiny && (
         <WidgetHeader
-          title={localConfig.title || DEFAULT_CONFIG.title}
+          title={width === 1 ? undefined : localConfig.title || DEFAULT_CONFIG.title}
           onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
-          compact={isShort}
+          compact={isShort || width === 1}
         />
       )}
 

--- a/src/components/widgets/ServicesWidget/types.ts
+++ b/src/components/widgets/ServicesWidget/types.ts
@@ -7,7 +7,7 @@ export interface Service {
   id: string;
   name: string;
   url: string;
-  icon?: string; // Lucide icon name or URL to icon
+  icon?: string; // Icon key or URL to icon
   description?: string;
   category?: string;
   statusUrl?: string; // URL to check for health (defaults to url)

--- a/src/components/widgets/WeatherWidget/index.tsx
+++ b/src/components/widgets/WeatherWidget/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, type FC, useCallback } from 'react';
 import { toast } from 'sonner';
 import { useVisibilityRefresh } from '../../../lib/useVisibilityRefresh';
-import { Cloud, CloudRain, CloudSnow, CloudLightning, Wind, Sun, SunDim, Droplets, Info, Search, MapPin, Loader2, Thermometer, Gauge, Sunrise, Sunset, Settings } from 'lucide-react';
+import { Cloud, CloudRain, CloudSnow, CloudLightning, Wind, Sun, SunDim, Droplets, Info, Search, MapPin, Loader2, Thermometer, Gauge, Sunrise, Sunset, Settings2 } from 'lucide-react';
 import { Skeleton } from '../../ui/skeleton';
 import { RadioGroup, RadioGroupItem } from '../../ui/radio-group';
 import { WidgetSettingsDialog, WidgetSettingsDialogFooter } from '../../widgets/common/WidgetSettingsDialog';
@@ -984,7 +984,7 @@ const WeatherWidget: FC<WeatherWidgetProps> = ({ width, height, config, refreshI
                 setIsSettingsOpen(true);
               }}
             >
-              <Settings size={16} className="text-muted-foreground" />
+              <Settings2 size={16} className="text-muted-foreground" />
             </Button>
           )}
         </div>

--- a/src/components/widgets/WorldClocksWidget/index.tsx
+++ b/src/components/widgets/WorldClocksWidget/index.tsx
@@ -20,6 +20,22 @@ import {
   CardTitle,
 } from '../../ui/card'
 
+const timezoneOffsetFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+const getTimezoneOffsetFormatter = (timezone: string): Intl.DateTimeFormat => {
+  const cached = timezoneOffsetFormatterCache.get(timezone);
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    timeZoneName: 'shortOffset',
+  });
+  timezoneOffsetFormatterCache.set(timezone, formatter);
+  return formatter;
+};
+
 /**
  * World Clocks Widget Component
  *
@@ -204,6 +220,22 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
   const getCityLabel = (name: string): string => name.split(',')[0].trim();
 
+  const getRegionLabel = (name: string): string => name.split(',').slice(1).join(',').trim();
+
+  const getTinyCityLabel = (name: string): string => {
+    const city = getCityLabel(name);
+    if (city.length <= 6) {
+      return city;
+    }
+
+    const region = getRegionLabel(name);
+    if (/city$/i.test(city) && region && region.length <= 8) {
+      return region;
+    }
+
+    return getCityCode(name);
+  };
+
   const getCityCode = (name: string): string => {
     const city = getCityLabel(name);
     const words = city.split(/\s+/).filter(Boolean);
@@ -217,10 +249,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
   const getTimezoneOffsetLabel = (timezone: string): string => {
     try {
-      const offsetPart = new Intl.DateTimeFormat('en-US', {
-        timeZone: timezone,
-        timeZoneName: 'shortOffset',
-      })
+      const offsetPart = getTimezoneOffsetFormatter(timezone)
         .formatToParts(currentTime)
         .find(part => part.type === 'timeZoneName')?.value;
 
@@ -660,7 +689,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
           {renderClock(mainTimezone.timezone, 40, isDarkMode)}
         </div>
         <div className="max-w-full truncate text-[10px] font-semibold leading-[1.15] text-foreground">
-          {getCityLabel(mainTimezone.name)}
+          {getTinyCityLabel(mainTimezone.name)}
         </div>
       </div>
     );
@@ -1009,18 +1038,14 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
   const renderWideView = (): React.ReactElement => {
     const isShallow = height <= 2;
     const isDarkMode = document.documentElement.classList.contains('dark');
-    const columns = Math.min(
-      timezones.length,
-      width >= 6 ? 6 : width >= 4 ? 4 : 3
-    );
-    const visibleTimezones = timezones.slice(0, columns);
+    const columns = Math.min(timezones.length, width >= 6 ? 6 : width >= 4 ? 4 : 3);
 
     return (
       <div
-        className={`grid h-full min-h-0 items-center overflow-hidden ${isShallow ? 'gap-3 px-3 py-1' : 'gap-3 px-3 py-2'}`}
+        className={`grid h-full min-h-0 auto-rows-min content-start overflow-y-auto overflow-x-hidden ${isShallow ? 'gap-x-3 gap-y-2 px-3 py-1' : 'gap-3 px-3 py-2'}`}
         style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
       >
-        {visibleTimezones.map(tz => {
+        {timezones.map(tz => {
           const display = getTimezoneDisplay(tz);
 
           return (

--- a/src/components/widgets/WorldClocksWidget/index.tsx
+++ b/src/components/widgets/WorldClocksWidget/index.tsx
@@ -204,46 +204,34 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
   const getCityLabel = (name: string): string => name.split(',')[0].trim();
 
-  const abbreviateWord = (word: string, maxLength: number): string => {
-    if (word.length <= maxLength) {
-      return word;
-    }
-
-    if (maxLength <= 1) {
-      return word.slice(0, Math.max(maxLength, 0));
-    }
-
-    return `${word.slice(0, maxLength - 1)}.`;
-  };
-
-  const getTinyLabelLines = (name: string): string[] => {
+  const getCityCode = (name: string): string => {
     const city = getCityLabel(name);
-
-    if (city.length <= 10) {
-      return [city];
-    }
-
     const words = city.split(/\s+/).filter(Boolean);
 
-    if (words.length === 1) {
-      return [abbreviateWord(words[0], 9)];
+    if (words.length > 1) {
+      return words.map(word => word[0]).join('').slice(0, 3).toUpperCase();
     }
 
-    if (words.length === 2) {
-      if (city.length <= 12) {
-        return [city];
+    return city.slice(0, 3).toUpperCase();
+  };
+
+  const getTimezoneOffsetLabel = (timezone: string): string => {
+    try {
+      const offsetPart = new Intl.DateTimeFormat('en-US', {
+        timeZone: timezone,
+        timeZoneName: 'shortOffset',
+      })
+        .formatToParts(currentTime)
+        .find(part => part.type === 'timeZoneName')?.value;
+
+      if (!offsetPart) {
+        return getTimeDiff(timezone);
       }
 
-      return words.map((word) => abbreviateWord(word, 7));
+      return offsetPart === 'GMT' ? 'GMT+0' : offsetPart;
+    } catch {
+      return getTimeDiff(timezone);
     }
-
-    const firstLine = words
-      .slice(0, 2)
-      .map((word, index) => (index === 0 ? abbreviateWord(word, 6) : `${word[0]}.`))
-      .join(' ');
-    const secondLine = words.slice(2).map((word) => `${word[0]}.`).join(' ');
-
-    return [firstLine, secondLine];
   };
 
   const getTimezoneDisplay = (timezoneItem: TimezoneItem) => {
@@ -438,6 +426,8 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
       const seconds = date.getSeconds();
       const minutes = date.getMinutes();
       const hours = date.getHours() % 12;
+      const isNight = !isDaytime(currentTime, timezone);
+      const useDarkDial = isDarkMode || isNight;
 
       // Smooth second hand movement
       const secondAngle = ((seconds) / 60) * 360;
@@ -446,86 +436,205 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
       // Calculate dimensions
       const center = size / 2;
-      const radius = size / 2 - 2;
+      const radius = size / 2 - 2.5;
+      const showFullNumerals = size >= 96;
+      const showCardinalNumerals = !showFullNumerals && size >= 46;
+      const tickCount = size >= 56 ? 60 : 12;
 
-      // Hand lengths - Bauhaus proportions
-      const hourHandLength = radius * 0.5;
-      const minuteHandLength = radius * 0.72;
-      const secondHandLength = radius * 0.8;
+      // Hand lengths tuned for a Bauhaus-style dial: long, light, and precise.
+      const hourHandLength = radius * 0.48;
+      const minuteHandLength = radius * 0.74;
+      const secondHandLength = radius * 0.82;
 
-      // Bauhaus-inspired colors
-      const handColor = isDarkMode ? '#f8fafc' : '#1e293b';
-      const secondHandColor = '#ef4444'; // Bauhaus red accent
-      const markerColor = isDarkMode ? '#475569' : '#cbd5e1';
+      const dialFill = useDarkDial ? '#0f172a' : '#ffffff';
+      const dialColor = useDarkDial ? '#64748b' : '#dbe1ea';
+      const majorTickColor = useDarkDial ? '#e2e8f0' : '#7a859b';
+      const minorTickColor = useDarkDial ? '#64748b' : '#c4cad6';
+      const numeralColor = useDarkDial ? '#dbeafe' : '#44506a';
+      const handColor = useDarkDial ? '#f8fafc' : '#0f172a';
+      const handHighlightColor = useDarkDial ? '#94a3b8' : '#ffffff';
+      const secondHandColor = '#ef4444';
+      const hourStroke = Math.max(2, size * 0.046);
+      const minuteStroke = Math.max(1.35, size * 0.028);
+      const secondStroke = Math.max(0.85, size * 0.012);
 
       return (
-        <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="clock">
-          {/* Minimal hour markers - just tiny dots at 12, 3, 6, 9 */}
-          {[0, 3, 6, 9].map((hour) => {
-            const angle = (hour * 30) * (Math.PI / 180);
-            const markerRadius = hour === 0 ? radius * 0.06 : radius * 0.04;
-            const x = center + (radius * 0.85) * Math.sin(angle);
-            const y = center - (radius * 0.85) * Math.cos(angle);
+        <svg
+          width={size}
+          height={size}
+          viewBox={`0 0 ${size} ${size}`}
+          className="clock overflow-visible"
+          data-clock-period={isNight ? 'night' : 'day'}
+          aria-hidden="true"
+        >
+          <circle
+            cx={center}
+            cy={center}
+            r={radius * 0.96}
+            fill={dialFill}
+            stroke={dialColor}
+            strokeWidth={Math.max(0.55, size * 0.009)}
+            opacity={useDarkDial ? 1 : 0.96}
+          />
+
+          {Array.from({ length: tickCount }, (_, index) => {
+            const minuteIndex = tickCount === 60 ? index : index * 5;
+            const isFive = minuteIndex % 5 === 0;
+            const isQuarter = minuteIndex % 15 === 0;
+            const angle = minuteIndex * 6 * (Math.PI / 180);
+            const tickOuter = radius * 0.93;
+            const tickInner = radius * (isQuarter ? 0.72 : isFive ? 0.78 : 0.86);
+            const x1 = center + tickInner * Math.sin(angle);
+            const y1 = center - tickInner * Math.cos(angle);
+            const x2 = center + tickOuter * Math.sin(angle);
+            const y2 = center - tickOuter * Math.cos(angle);
 
             return (
-              <circle
-                key={hour}
-                cx={x}
-                cy={y}
-                r={markerRadius}
-                fill={markerColor}
+              <line
+                key={index}
+                x1={x1}
+                y1={y1}
+                x2={x2}
+                y2={y2}
+                stroke={isFive ? majorTickColor : minorTickColor}
+                strokeWidth={
+                  isQuarter
+                    ? Math.max(1.45, size * 0.032)
+                    : isFive
+                      ? Math.max(1.05, size * 0.021)
+                      : Math.max(0.5, size * 0.009)
+                }
+                strokeLinecap="round"
+                opacity={isFive ? 0.95 : 0.7}
               />
             );
           })}
 
-          {/* Hour hand - bold, geometric rectangle */}
-          <rect
-            x={center - size * 0.025}
-            y={center - hourHandLength}
-            width={size * 0.05}
-            height={hourHandLength}
-            fill={handColor}
-            transform={`rotate(${hourAngle}, ${center}, ${center})`}
-            rx={size * 0.01}
-          />
+          {showFullNumerals ? (
+            <>
+              {Array.from({ length: 12 }, (_, index) => {
+                const hour = index === 0 ? 12 : index;
+                const angle = hour * 30 * (Math.PI / 180);
+                const numeralRadius = radius * 0.6;
 
-          {/* Minute hand - slimmer rectangle */}
-          <rect
-            x={center - size * 0.018}
-            y={center - minuteHandLength}
-            width={size * 0.036}
-            height={minuteHandLength}
-            fill={handColor}
-            transform={`rotate(${minuteAngle}, ${center}, ${center})`}
-            rx={size * 0.008}
-          />
+                return {
+                  label: String(hour),
+                  x: center + numeralRadius * Math.sin(angle),
+                  y: center - numeralRadius * Math.cos(angle),
+                };
+              }).map(({ label, x, y }) => (
+                <text
+                  key={label}
+                  x={x}
+                  y={y}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fill={numeralColor}
+                  fontSize={Math.max(7.5, size * 0.155)}
+                  fontWeight={500}
+                >
+                  {label}
+                </text>
+              ))}
+            </>
+          ) : showCardinalNumerals ? (
+            <>
+              {[
+                { label: '12', x: center, y: center - radius * 0.56 },
+                { label: '3', x: center + radius * 0.58, y: center + size * 0.012 },
+                { label: '6', x: center, y: center + radius * 0.66 },
+                { label: '9', x: center - radius * 0.58, y: center + size * 0.012 },
+              ].map(({ label, x, y }) => (
+                <text
+                  key={label}
+                  x={x}
+                  y={y}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fill={numeralColor}
+                  fontSize={Math.max(7, size * 0.15)}
+                  fontWeight={500}
+                >
+                  {label}
+                </text>
+              ))}
+            </>
+          ) : null}
 
-          {/* Second hand - thin line with counterweight */}
+          <g transform={`rotate(${hourAngle}, ${center}, ${center})`}>
+            <line
+              x1={center}
+              y1={center + radius * 0.06}
+              x2={center}
+              y2={center - hourHandLength}
+              stroke={handColor}
+              strokeWidth={hourStroke}
+              strokeLinecap="round"
+            />
+            <line
+              x1={center}
+              y1={center - radius * 0.02}
+              x2={center}
+              y2={center - hourHandLength * 0.82}
+              stroke={handHighlightColor}
+              strokeWidth={Math.max(0.55, hourStroke * 0.28)}
+              strokeLinecap="round"
+              opacity={isDarkMode ? 0.18 : 0.72}
+            />
+          </g>
+
+          <g transform={`rotate(${minuteAngle}, ${center}, ${center})`}>
+            <line
+              x1={center}
+              y1={center + radius * 0.12}
+              x2={center}
+              y2={center - minuteHandLength}
+              stroke={handColor}
+              strokeWidth={minuteStroke}
+              strokeLinecap="round"
+            />
+            <line
+              x1={center}
+              y1={center - radius * 0.02}
+              x2={center}
+              y2={center - minuteHandLength * 0.9}
+              stroke={handHighlightColor}
+              strokeWidth={Math.max(0.45, minuteStroke * 0.28)}
+              strokeLinecap="round"
+              opacity={isDarkMode ? 0.16 : 0.7}
+            />
+          </g>
+
           <g transform={`rotate(${secondAngle}, ${center}, ${center})`}>
-            {/* Main hand */}
             <line
               x1={center}
               y1={center + radius * 0.2}
               x2={center}
               y2={center - secondHandLength}
               stroke={secondHandColor}
-              strokeWidth={size * 0.012}
+              strokeWidth={secondStroke}
               strokeLinecap="round"
             />
-            {/* Counterweight circle */}
             <circle
               cx={center}
-              cy={center + radius * 0.15}
-              r={size * 0.025}
+              cy={center + radius * 0.17}
+              r={Math.max(0.8, size * 0.015)}
               fill={secondHandColor}
             />
           </g>
 
-          {/* Center cap */}
           <circle
             cx={center}
             cy={center}
-            r={size * 0.04}
+            r={Math.max(2.3, size * 0.048)}
+            fill={useDarkDial ? '#020617' : '#ffffff'}
+            stroke={handColor}
+            strokeWidth={Math.max(1.2, size * 0.028)}
+          />
+          <circle
+            cx={center}
+            cy={center}
+            r={Math.max(1.2, size * 0.022)}
             fill={handColor}
           />
         </svg>
@@ -542,33 +651,38 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
    * @returns {React.ReactElement} Compact view optimized for 1x1 grid size
    */
   const renderCompactView = (): React.ReactElement => {
+    const isDarkMode = document.documentElement.classList.contains('dark');
     const mainTimezone = timezones[0] || { id: 0, name: 'Local', timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
-    const { time, period } = getTimezoneDisplay(mainTimezone);
-    const labelLines = getTinyLabelLines(mainTimezone.name);
 
     return (
-      <div className="flex h-full flex-col items-center justify-between px-1 py-0.5 text-center">
-        <div
-          className="font-semibold text-foreground"
-          style={{ fontSize: '1.64rem', lineHeight: 1.06, letterSpacing: '-0.045em' }}
-        >
-          {time}
+      <div className="flex h-full flex-col items-center justify-center gap-0.5 overflow-hidden text-center">
+        <div className="flex items-center justify-center">
+          {renderClock(mainTimezone.timezone, 40, isDarkMode)}
         </div>
-        <div
-          className="flex min-h-[1.35rem] flex-col items-center justify-center text-foreground/90"
-          style={{ fontSize: '0.58rem', lineHeight: 1.05 }}
-        >
-          {labelLines.map((line, index) => (
-            <span key={`${mainTimezone.id}-${index}`} className="block max-w-full whitespace-nowrap">
-              {line}
-            </span>
-          ))}
+        <div className="max-w-full truncate text-[10px] font-semibold leading-[1.15] text-foreground">
+          {getCityLabel(mainTimezone.name)}
         </div>
-        <div
-          className="rounded-full bg-muted px-1.5 py-0.5 font-semibold uppercase text-muted-foreground"
-          style={{ fontSize: '0.47rem', lineHeight: 1, letterSpacing: '0.16em' }}
-        >
-          {period || 'LOCAL'}
+      </div>
+    );
+  };
+
+  const renderNarrowView = (): React.ReactElement => {
+    const isDarkMode = document.documentElement.classList.contains('dark');
+    const mainTimezone = timezones[0] || { id: 0, name: 'Local', timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
+    const display = getTimezoneDisplay(mainTimezone);
+    const clockSize = height >= 3 ? 56 : 44;
+
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-1.5 overflow-hidden px-1.5 py-2 text-center">
+        <div className="flex shrink-0 items-center justify-center">
+          {renderClock(mainTimezone.timezone, clockSize, isDarkMode)}
+        </div>
+        <div className="max-w-full truncate text-sm font-semibold leading-tight text-foreground">
+          {getCityCode(mainTimezone.name)}
+        </div>
+        <div className="max-w-full truncate text-[10px] font-medium leading-tight text-muted-foreground">
+          {display.time}
+          <span className="ml-1 uppercase">{display.period}</span>
         </div>
       </div>
     );
@@ -583,37 +697,52 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
     const mainTz = timezones[0] || { id: 0, name: 'Local', timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
     const mainTime = formatTime(currentTime, mainTz.timezone).split(':').slice(0, 2).join(':');
     const mainPeriod = formatTime(currentTime, mainTz.timezone).split(' ')[1];
-    const chipCount = Math.min(timezones.length - 1, Math.max(2, width - 1));
+    const chipCount = Math.min(timezones.length - 1, width >= 4 ? 3 : width >= 3 ? 2 : 1);
     const chipTimezones = timezones.slice(1, 1 + chipCount);
+    const tightRibbon = width <= 2;
+
+    if (tightRibbon) {
+      return (
+        <div className="flex h-full min-w-0 items-center justify-center gap-1.5 overflow-hidden px-2">
+          <div className="flex min-w-0 shrink-0 items-baseline gap-1">
+            <span className="text-sm font-semibold leading-tight text-foreground">
+              {mainTime}
+            </span>
+            <span className="text-[10px] font-medium uppercase text-muted-foreground">
+              {getCityCode(mainTz.name)}
+            </span>
+          </div>
+        </div>
+      );
+    }
 
     return (
-      <div className="flex h-full items-center gap-2 overflow-x-auto px-1 text-xs">
-        {/* Primary timezone */}
-        <span className="shrink-0 font-semibold text-sm text-foreground">
-          {mainTime}
-          <span className="ml-0.5 text-[10px] font-normal text-muted-foreground uppercase">{mainPeriod}</span>
-        </span>
-        <span className="shrink-0 truncate text-[11px] font-medium text-muted-foreground">
-          {mainTz.name.split(',')[0]}
+      <div className="flex h-full items-center gap-2 overflow-hidden px-2 text-xs">
+        <div className="flex min-w-0 shrink-0 items-baseline gap-1">
+          <span className="text-base font-semibold leading-none text-foreground">
+            {mainTime}
+          </span>
+          <span className="text-[10px] font-medium uppercase text-muted-foreground">{mainPeriod}</span>
+        </div>
+        <span className="min-w-0 shrink truncate text-[11px] font-medium text-muted-foreground">
+          {getCityLabel(mainTz.name)}
         </span>
 
-        {/* Divider */}
         {chipTimezones.length > 0 && (
           <span className="h-4 w-px shrink-0 bg-border" />
         )}
 
-        {/* Other timezone chips */}
         {chipTimezones.map((tz) => {
           const t = formatTime(currentTime, tz.timezone).split(':').slice(0, 2).join(':');
           const p = formatTime(currentTime, tz.timezone).split(' ')[1];
-          const city = tz.name.split(',')[0];
+          const city = getCityLabel(tz.name);
           return (
             <span
               key={tz.id}
-              className="flex shrink-0 items-center gap-1.5 rounded-full border border-border bg-card px-2.5 py-1 text-foreground ring-1 ring-border"
+              className="flex min-w-0 shrink-0 items-baseline gap-1 rounded-full bg-muted px-2 py-1 text-foreground"
             >
-              <span className="max-w-[6rem] truncate">{city}</span>
-              <span className="font-medium">{t}</span>
+              <span className="max-w-[4.25rem] truncate">{city}</span>
+              <span className="font-semibold">{t}</span>
               <span className="text-[10px] uppercase text-muted-foreground">{p}</span>
             </span>
           );
@@ -624,20 +753,22 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
   // ── 6x6+ App View ──────────────────────────────────────────────
   /**
-   * Renders a full world-clock dashboard for 6x6+ "app" sizes.
-   * Each timezone gets a large analog clock, digital time, date line,
-   * time difference from local, and a day/night indicator.
+   * Renders a scan-first board for 6x6+ "app" sizes.
+   * The large surface adds comparison and context without turning the widget
+   * into an analog-clock gallery.
    */
   const renderAppView = (): React.ReactElement => {
-    const isDarkMode = document.documentElement.classList.contains('dark');
-    // Responsive grid: aim for 3-4 columns depending on width
-    const cols = width >= 8 ? 4 : 3;
+    const cols = width >= 10 ? 4 : width >= 7 ? 3 : 2;
 
     return (
-      <div className="flex h-full flex-col overflow-hidden">
-        {/* Title bar for app view */}
-        <div className="flex items-center justify-between px-4 pt-3 pb-2 widget-drag-handle cursor-move">
-          <h2 className="text-base font-semibold text-foreground">World Clocks</h2>
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <div className="widget-drag-handle flex cursor-move items-center justify-between gap-3 px-4 py-3">
+          <div className="min-w-0">
+            <h2 className="truncate text-base font-semibold text-foreground">World Clocks</h2>
+            <p className="text-xs text-muted-foreground">
+              {timezones.length} timezone{timezones.length === 1 ? '' : 's'} tracked
+            </p>
+          </div>
           {!readOnly && (
             <Button
               variant="ghost"
@@ -649,12 +780,11 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
           )}
         </div>
 
-        {/* Clock grid */}
         <div
-          className="grid flex-1 gap-4 overflow-y-auto px-4 pb-4"
+          className="grid min-h-0 flex-1 gap-3 overflow-y-auto px-4 pb-4"
           style={{
             gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
-            gridAutoRows: 'minmax(180px, auto)',
+            gridAutoRows: 'minmax(104px, auto)',
           }}
         >
           {timezones.map((tz) => {
@@ -669,40 +799,96 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
             return (
               <div
                 key={tz.id}
-                className="flex flex-col items-center justify-center rounded-xl border border-border bg-muted/60 p-4 transition-all duration-300"
+                className="flex min-w-0 flex-col justify-between rounded-lg border border-border/60 bg-muted/35 p-3"
               >
-                {/* City name */}
-                <div className="mb-2 text-sm font-semibold text-foreground truncate w-full text-center">
-                  {tz.name}
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold text-foreground">
+                    {tz.name}
+                  </div>
+                  <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{dateLine}</span>
+                    <span className="h-3 w-px bg-border" aria-hidden="true" />
+                    <span>{diff}</span>
+                  </div>
                 </div>
 
-                {/* Analog clock */}
-                <div className="mb-2">
-                  {renderClock(tz.timezone, 100, isDarkMode)}
-                </div>
-
-                {/* Digital time */}
-                <div className="text-2xl font-light tracking-tighter leading-none">
-                  {timeParts}
-                  <span className="ml-1 text-sm font-normal text-muted-foreground">{period}</span>
-                </div>
-
-                {/* Date line */}
-                <div className="mt-1.5 text-xs text-muted-foreground tracking-wide">
-                  {dateLine}
-                </div>
-
-                {/* Day/night + time diff */}
-                <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                  <DayNightIcon className="h-3.5 w-3.5" />
-                  <span>{day ? 'Day' : 'Night'}</span>
-                  <span className="h-3 w-px bg-border" />
-                  <span>{diff}</span>
+                <div className="mt-4 flex items-end justify-between gap-3">
+                  <div className="text-3xl font-semibold leading-none text-foreground">
+                    {timeParts}
+                    <span className="ml-1 text-sm font-medium uppercase text-muted-foreground">
+                      {period}
+                    </span>
+                  </div>
+                  <div className="mb-0.5 flex shrink-0 items-center gap-1 rounded-full bg-background/70 px-2 py-1 text-xs text-muted-foreground">
+                    <DayNightIcon className="h-3.5 w-3.5" />
+                    {day ? 'Day' : 'Night'}
+                  </div>
                 </div>
               </div>
             );
           })}
         </div>
+      </div>
+    );
+  };
+
+  const renderHeroClockView = (): React.ReactElement => {
+    const isDarkMode = document.documentElement.classList.contains('dark');
+    const primaryTimezone = timezones[0] || {
+      id: 0,
+      name: 'Local',
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    };
+    const primary = getTimezoneDisplay(primaryTimezone);
+    const secondaryTimezones = timezones.slice(1, 4);
+    const isNarrowHero = width <= 2 && height <= 2;
+    const layoutScale = getAreaScale(4, 10);
+    const heroClockSize = isNarrowHero ? 48 : Math.round(interpolate(54, 72, layoutScale));
+    const secondaryClockSize = isNarrowHero ? 31 : Math.round(interpolate(34, 46, layoutScale));
+    const primaryCitySize = isNarrowHero ? '1.08rem' : `${interpolate(1.35, 1.65, layoutScale)}rem`;
+
+    return (
+      <div className="flex h-full min-h-0 flex-col justify-center gap-2.5 overflow-hidden p-2.5">
+        <div className="flex min-h-0 items-center gap-2.5 px-2.5 py-1.5">
+          <div className="flex shrink-0 items-center justify-center">
+            {renderClock(primaryTimezone.timezone, heroClockSize, isDarkMode)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-xs font-medium text-muted-foreground">
+              {getTimezoneOffsetLabel(primaryTimezone.timezone)}
+            </div>
+            <div
+              className={`${isNarrowHero ? 'max-w-full whitespace-normal' : 'truncate'} font-semibold leading-tight text-foreground`}
+              style={{ fontSize: primaryCitySize, overflowWrap: 'anywhere' }}
+              title={primary.city}
+            >
+              {primary.city}
+            </div>
+            {!isNarrowHero ? (
+              <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                {primary.time} {primary.period} · {primary.diff}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {secondaryTimezones.length ? (
+          <div className="grid shrink-0 grid-cols-3 gap-2">
+            {secondaryTimezones.map(tz => (
+              <div
+                key={tz.id}
+                className="flex min-w-0 flex-col items-center gap-1 px-1.5 py-1 text-center"
+              >
+                <div className="flex items-center justify-center">
+                  {renderClock(tz.timezone, secondaryClockSize, isDarkMode)}
+                </div>
+                <div className="max-w-full truncate text-sm font-semibold leading-none text-foreground">
+                  {getCityCode(tz.name)}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
     );
   };
@@ -812,41 +998,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
    * @returns {React.ReactElement} Medium view optimized for 2x2 grid size with multiple timezones
    */
   const renderMediumView = (): React.ReactElement => {
-    return (
-      <div className="grid h-full min-h-0 grid-cols-2 grid-rows-2 overflow-y-auto p-2" style={{ gap: '0.55rem' }}>
-        {timezones.map(tz => {
-          const display = getTimezoneDisplay(tz);
-
-          return (
-            <div
-              key={tz.id}
-              className="flex min-h-0 flex-col items-center justify-between overflow-hidden rounded-xl border border-border/60 bg-muted/35 px-2 py-2 text-center"
-            >
-              <div
-                className="min-h-[1.7rem] w-full px-1 font-semibold text-foreground"
-                style={{ fontSize: '0.72rem', lineHeight: 1.1 }}
-              >
-                {display.city}
-              </div>
-              <div
-                className="mt-1 font-light text-foreground"
-                style={{ fontSize: '1.15rem', lineHeight: 1, letterSpacing: '-0.05em' }}
-              >
-                {display.time}
-              </div>
-              <div
-                className="mt-1 flex items-center justify-center gap-1 text-muted-foreground"
-                style={{ fontSize: '0.56rem', lineHeight: 1.1, letterSpacing: '0.08em' }}
-              >
-                <span>{display.diff}</span>
-                <span className="h-1 w-1 rounded-full bg-border" />
-                <span className="uppercase">{display.period}</span>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
+    return renderHeroClockView();
   };
 
   /**
@@ -855,66 +1007,41 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
    * @returns {React.ReactElement} Wide view optimized for 3x2 grid size
    */
   const renderWideView = (): React.ReactElement => {
+    const isShallow = height <= 2;
     const isDarkMode = document.documentElement.classList.contains('dark');
+    const columns = Math.min(
+      timezones.length,
+      width >= 6 ? 6 : width >= 4 ? 4 : 3
+    );
+    const visibleTimezones = timezones.slice(0, columns);
 
-    // For 1-3 timezones, show analog clocks
-    if (timezones.length <= 3) {
-      return (
-        <div className="grid grid-cols-3 gap-3 h-full transition-all duration-300">
-          {timezones.map(tz => (
-            <div key={tz.id} className="flex flex-col items-center justify-center h-full transition-all duration-300">
-              <div className="text-xs font-medium tracking-tight text-foreground mb-1 truncate w-full text-center">
-                {tz.name}
-              </div>
-              <div className="mb-0.5">
-                {renderClock(tz.timezone, 50, isDarkMode)}
-              </div>
-              <div className="text-base font-light tracking-tighter">
-                {formatTime(currentTime, tz.timezone).split(':').slice(0, 2).join(':')}
-              </div>
-            </div>
-          ))}
-        </div>
-      );
-    }
-
-    // For 4-6 timezones, show digital clocks in a 3x2 grid
-    if (timezones.length <= 6) {
-      return (
-        <div className="grid grid-cols-3 grid-rows-2 gap-x-3 gap-y-2 h-full transition-all duration-300">
-          {timezones.slice(0, 6).map(tz => (
-            <div key={tz.id} className="flex flex-col items-center justify-center h-full transition-all duration-300">
-              <div className="text-lg font-light tracking-tighter leading-none">
-                {formatTime(currentTime, tz.timezone).split(':').slice(0, 2).join(':')}
-              </div>
-              <div className="text-xs font-medium tracking-tight text-foreground truncate w-full text-center mt-0.5">
-                {tz.name}
-              </div>
-              <div className="text-xs text-muted-foreground tracking-wide">
-                {getTimeDiff(tz.timezone)}
-              </div>
-            </div>
-          ))}
-        </div>
-      );
-    }
-
-    // For 7+ timezones, use a more compact grid with scrolling
     return (
-      <div className="grid grid-cols-3 auto-rows-min gap-x-3 gap-y-2 h-full overflow-y-auto transition-all duration-300">
-        {timezones.map(tz => (
-          <div key={tz.id} className="flex flex-col items-center justify-center py-1 transition-all duration-300">
-            <div className="text-base font-light tracking-tighter leading-none">
-              {formatTime(currentTime, tz.timezone).split(':').slice(0, 2).join(':')}
+      <div
+        className={`grid h-full min-h-0 items-center overflow-hidden ${isShallow ? 'gap-3 px-3 py-1' : 'gap-3 px-3 py-2'}`}
+        style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+      >
+        {visibleTimezones.map(tz => {
+          const display = getTimezoneDisplay(tz);
+
+          return (
+            <div key={tz.id} className="min-w-0 text-center">
+              {isShallow && (
+                <div className="mb-1 flex items-center justify-center">
+                  {renderClock(tz.timezone, width >= 4 ? 40 : 36, isDarkMode)}
+                </div>
+              )}
+              <div className={`${isShallow ? 'text-[1.18rem] leading-tight' : 'text-2xl leading-[1.12]'} truncate font-semibold text-foreground`}>
+                {display.time}
+              </div>
+              <div className={`${isShallow ? 'mt-0 text-[0.78rem]' : 'mt-1 text-sm'} truncate font-semibold leading-tight text-foreground`}>
+                {display.city}
+              </div>
+              <div className={`${isShallow ? 'mt-0 text-[0.68rem]' : 'mt-0.5 text-xs'} truncate font-medium leading-tight text-muted-foreground`}>
+                {display.diff}
+              </div>
             </div>
-            <div className="text-xs font-medium tracking-tight text-foreground truncate w-full text-center mt-0.5">
-              {tz.name}
-            </div>
-            <div className="text-xs text-muted-foreground tracking-wide">
-              {getTimeDiff(tz.timezone)}
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     );
   };
@@ -925,64 +1052,11 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
    * @returns {React.ReactElement} Tall view optimized for 2x3+ grid sizes
    */
   const renderTallView = (): React.ReactElement => {
-    const isDarkMode = document.documentElement.classList.contains('dark');
-    const layoutScale = getAreaScale(6, 16);
-    const clockSize = Math.round(interpolate(46, 64, layoutScale));
-    const gap = `${interpolate(0.625, 0.95, layoutScale)}rem`;
-    const cardPadding = `${interpolate(0.65, 0.95, layoutScale)}rem`;
-    const titleSize = `${interpolate(0.76, 0.94, layoutScale)}rem`;
-    const timeSize = `${interpolate(1.05, 1.55, layoutScale)}rem`;
-    const metaSize = `${interpolate(0.58, 0.76, layoutScale)}rem`;
-
-    // For 1-4 timezones, show larger clocks with more details
     if (timezones.length <= 4) {
-      const rows = Math.ceil(timezones.length / 2);
-
-      return (
-        <div
-          className="grid h-full min-h-0 grid-cols-2 transition-all duration-300"
-          style={{ gap, gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))` }}
-        >
-          {timezones.map(tz => {
-            const display = getTimezoneDisplay(tz);
-
-            return (
-              <div
-                key={tz.id}
-                className="flex min-h-0 flex-col items-center justify-between overflow-hidden rounded-2xl border border-border/60 bg-muted/35 text-center transition-all duration-300"
-                style={{ padding: cardPadding }}
-              >
-                <div
-                  className="min-h-[1.6rem] w-full px-1 font-semibold text-foreground"
-                  style={{ fontSize: titleSize, lineHeight: 1.12 }}
-                >
-                  {display.city}
-                </div>
-                <div className="my-1 flex grow items-center justify-center">
-                  {renderClock(tz.timezone, clockSize, isDarkMode)}
-                </div>
-                <div
-                  className="font-light text-foreground"
-                  style={{ fontSize: timeSize, lineHeight: 1, letterSpacing: '-0.05em' }}
-                >
-                  {display.time}
-                </div>
-                <div
-                  className="mt-1 flex items-center justify-center gap-1 text-muted-foreground"
-                  style={{ fontSize: metaSize, lineHeight: 1.1 }}
-                >
-                  <span>{display.diff}</span>
-                  <span className="h-1 w-1 rounded-full bg-border" />
-                  <span className="uppercase" style={{ letterSpacing: '0.14em' }}>
-                    {display.period}
-                  </span>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      );
+      return renderHeroClockView();
     }
+
+    const isDarkMode = document.documentElement.classList.contains('dark');
 
     // For 5+ timezones, use a compact layout with smaller clocks
     return (
@@ -1118,7 +1192,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
           {timezones.map(tz => (
             <div key={tz.id} className="flex flex-col items-center justify-center h-full transition-all duration-300">
               <div className="text-sm font-medium tracking-tight text-foreground mb-1 truncate w-full text-center">
-                {tz.name}
+                {getCityLabel(tz.name)}
               </div>
               <div className="relative mb-1">
                 {renderClock(tz.timezone, 46, isDarkMode)}
@@ -1148,7 +1222,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
                 {formatTime(currentTime, tz.timezone).split(':').slice(0, 2).join(':')}
               </div>
               <div className="text-xs font-medium tracking-tight text-foreground truncate w-full text-center mt-0.5">
-                {tz.name}
+                {getCityLabel(tz.name)}
               </div>
               <div className="text-xs text-muted-foreground tracking-wide">
                 {getTimeDiff(tz.timezone)}
@@ -1168,7 +1242,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
               {formatTime(currentTime, tz.timezone).split(':').slice(0, 2).join(':')}
             </div>
             <div className="text-xs font-medium tracking-tight text-foreground truncate w-full text-center mt-0.5">
-              {tz.name}
+              {getCityLabel(tz.name)}
             </div>
             <div className="text-xs text-muted-foreground tracking-wide">
               {getTimeDiff(tz.timezone)}
@@ -1192,7 +1266,7 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
         {timezones.map(tz => (
           <div key={tz.id} className="flex flex-col items-center justify-center h-full transition-all duration-300">
             <div className="text-sm font-medium tracking-tight text-foreground mb-1 truncate w-full text-center">
-              {tz.name}
+              {getCityLabel(tz.name)}
             </div>
             <div className="relative mb-1">
               {renderClock(tz.timezone, 70, isDarkMode)}
@@ -1242,6 +1316,11 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
       return renderCompactView();
     }
 
+    // 1xN narrow column: keep it to one primary clock.
+    if (width === 1) {
+      return renderNarrowView();
+    }
+
     // Nx1 ribbon
     if (isShort) {
       return renderRibbonView();
@@ -1252,7 +1331,11 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
       return renderAppView();
     }
 
-    // ── Existing size routing (unchanged) ─────────────────────────
+    // ── Size routing ──────────────────────────────────────────────
+
+    if (timezones.length <= 4 && width <= 4 && height <= 4 && width >= 2 && height >= 2) {
+      return renderHeroClockView();
+    }
 
     // Full size widgets - use the most detailed view
     if (width >= 4 && height >= 4) {
@@ -1567,18 +1650,19 @@ const WorldClocksWidget: React.FC<WorldClocksWidgetProps> = ({ width, height, co
 
   // ── Main return ─────────────────────────────────────────────────
   const suppressHeader = isTiny || isApp;
+  const headerTitle = width === 1 ? undefined : 'World Clocks';
 
   return (
-    <div ref={widgetRef} className={`widget-container h-full flex flex-col ${isTiny ? 'widget-drag-handle p-2.5' : ''}`}>
+    <div ref={widgetRef} className={`widget-container h-full flex flex-col ${isTiny ? 'widget-drag-handle' : ''}`}>
       {!suppressHeader && (
         <WidgetHeader
-          title="World Clocks"
+          title={headerTitle}
           onSettingsClick={readOnly ? undefined : () => setShowSettings(true)}
-          compact={isCompact || isShort}
+          compact={isCompact || isShort || width === 1 || height <= 2}
         />
       )}
 
-      <div className={`flex-1 overflow-hidden ${isTiny ? 'p-1' : ''}`}>
+      <div className={`flex-1 overflow-hidden ${isTiny ? 'p-1.5' : ''}`}>
         {renderContent()}
       </div>
 

--- a/src/components/widgets/YouTubeWidget/index.tsx
+++ b/src/components/widgets/YouTubeWidget/index.tsx
@@ -13,7 +13,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
-import { Play, PlaySquare, ExternalLink, Settings } from 'lucide-react';
+import { Play, PlaySquare, ExternalLink, Settings2 } from 'lucide-react';
 
 const PLAY_BUTTON_CHROME_CLASS = 'rounded-full bg-black/75 text-white shadow-lg';
 
@@ -151,7 +151,7 @@ const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({ width, height, config }) 
   // --- Setup prompt when no video configured ---
   const renderSetup = () => (
     <div className="flex-1 flex flex-col items-center justify-center gap-2 text-muted-foreground">
-      <Settings className="h-8 w-8" />
+      <Settings2 className="h-8 w-8" />
       <p className="text-sm">Configure a YouTube video</p>
       {!readOnly && (
         <Button variant="outline" size="sm" onClick={() => setShowSettings(true)}>

--- a/src/components/widgets/common/WidgetHeader.tsx
+++ b/src/components/widgets/common/WidgetHeader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { Settings } from 'lucide-react';
+import { Settings2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 import {
@@ -58,7 +58,7 @@ const WidgetHeader = ({
             onSettingsClick();
           }}
         >
-          <Settings aria-hidden="true" />
+          <Settings2 aria-hidden="true" />
         </Button>
       )}
     </div>

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -1115,3 +1115,37 @@ test('keeps world clock audit layouts within bounds from 1x1 through 4x4', async
     await expect.poll(async () => readOverflowingLeafNodes(page, widgetId)).toEqual([]);
   }
 });
+
+test('renders every configured timezone in shallow wide world clock layouts', async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await seedDashboard(page, {
+    widgets: [
+      {
+        id: 'world-clocks-wide-many',
+        type: 'world-clocks',
+        config: {
+          timezones: [
+            { id: 1, name: 'Mexico City, Mexico', timezone: 'America/Mexico_City' },
+            { id: 2, name: 'San Francisco, USA', timezone: 'America/Los_Angeles' },
+            { id: 3, name: 'New York, USA', timezone: 'America/New_York' },
+            { id: 4, name: 'London, UK', timezone: 'Europe/London' },
+            { id: 5, name: 'Tokyo, Japan', timezone: 'Asia/Tokyo' },
+          ],
+        },
+      },
+    ],
+    layouts: {
+      lg: [
+        { i: 'world-clocks-wide-many', x: 0, y: 0, w: 3, h: 2, minW: 1, minH: 1 },
+      ],
+    },
+  });
+
+  const widget = page.locator('.react-grid-item[data-widget-id="world-clocks-wide-many"]');
+  await expect(widget).toBeVisible();
+  await expect(widget).toContainText('Mexico City');
+  await expect(widget).toContainText('San Francisco');
+  await expect(widget).toContainText('New York');
+  await expect(widget).toContainText('London');
+  await expect(widget).toContainText('Tokyo');
+});

--- a/tests/e2e/services-widget.spec.ts
+++ b/tests/e2e/services-widget.spec.ts
@@ -22,6 +22,26 @@ const readStoredServicesConfig = async (page: Page, widgetId: string) => (
   }, widgetId)
 );
 
+const readStoredService = async (page: Page, widgetId: string, serviceName: string) => (
+  page.evaluate(({ currentWidgetId, targetServiceName }) => {
+    const configs = JSON.parse(localStorage.getItem('boxento-widget-configs') || '{}');
+    const config = configs[currentWidgetId] || {};
+    const service = (config.services ?? []).find((item: {
+      category?: string;
+      description?: string;
+      icon?: string;
+      name: string;
+    }) => item.name === targetServiceName);
+    return service
+      ? {
+          category: service.category,
+          description: service.description,
+          icon: service.icon,
+        }
+      : null;
+  }, { currentWidgetId: widgetId, targetServiceName: serviceName })
+);
+
 test('keeps compact services cards within a mobile two-column widget', async ({ page }) => {
   await page.setViewportSize({ width: 430, height: 932 });
   await seedDashboard(page, {
@@ -76,6 +96,8 @@ test('persists services settings changes from the tablet dialog flow', async ({ 
   const updatedCheckInterval = 120;
   const serviceToAdd = {
     category: 'Media',
+    description: 'Photo backup',
+    icon: 'Play',
     name: 'Immich',
     url: 'https://immich.test',
   } as const;
@@ -123,6 +145,9 @@ test('persists services settings changes from the tablet dialog flow', async ({ 
   await page.locator('#service-name').fill(serviceToAdd.name);
   await page.locator('#service-url').fill(serviceToAdd.url);
   await page.locator('#service-category').fill(serviceToAdd.category);
+  await page.getByText('Optional details').click();
+  await page.locator('#service-desc').fill(serviceToAdd.description);
+  await page.locator('#service-icon').fill(serviceToAdd.icon);
   await page.getByRole('button', { name: 'Add Service', exact: true }).click();
 
   await expect(settingsDialog).toContainText(serviceToAdd.name);
@@ -138,6 +163,11 @@ test('persists services settings changes from the tablet dialog flow', async ({ 
     showStatus: true,
     checkInterval: updatedCheckInterval,
     serviceNames: remainingServiceNames,
+  });
+  await expect.poll(async () => readStoredService(page, 'services-tablet', serviceToAdd.name)).toEqual({
+    category: serviceToAdd.category,
+    description: serviceToAdd.description,
+    icon: serviceToAdd.icon,
   });
 
   await page.reload();

--- a/tests/e2e/services-widget.spec.ts
+++ b/tests/e2e/services-widget.spec.ts
@@ -76,7 +76,6 @@ test('persists services settings changes from the tablet dialog flow', async ({ 
   const updatedCheckInterval = 120;
   const serviceToAdd = {
     category: 'Media',
-    description: 'Photo backup',
     name: 'Immich',
     url: 'https://immich.test',
   } as const;
@@ -123,7 +122,6 @@ test('persists services settings changes from the tablet dialog flow', async ({ 
 
   await page.locator('#service-name').fill(serviceToAdd.name);
   await page.locator('#service-url').fill(serviceToAdd.url);
-  await page.locator('#service-desc').fill(serviceToAdd.description);
   await page.locator('#service-category').fill(serviceToAdd.category);
   await page.getByRole('button', { name: 'Add Service', exact: true }).click();
 


### PR DESCRIPTION
## Summary
- Simplifies Services widget density, including compact cards, 6x6 directory mode, wide app detail mode, and the settings dialog.
- Redesigns World Clocks across tiny, ribbon, standard, and large sizes with clearer analog clocks and night-aware dials.
- Standardizes visible widget/dashboard settings controls on the shared config icon.

## PM-ready notes
- Tiny and narrow World Clocks now stay glanceable without header chrome or clipped titles.
- Services keeps small and mid-size widgets focused on service access and status, while 8x6+ preserves a detail pane for deeper inspection.
- Services settings now focus on title, status checks, refresh interval, and add/delete service setup.
- Loading/error/read-only behavior remains under existing widget shell and settings patterns.

## Validation
- `bun run build:types`
- `bun run lint` (0 errors, existing warnings only)
- `bun run test`
- `bun run test:e2e`
- `git diff --check`